### PR TITLE
Add simple toModelOutput support for text and JSON output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/tool2agent/tool2agent/issues/7
+Your prepared branch: issue-7-8cea7add7a79
+Your prepared working directory: /tmp/gh-issue-solver-1766657756607
+Your forked repository: konard/tool2agent-tool2agent
+Original repository (upstream): tool2agent/tool2agent
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/tool2agent/tool2agent/issues/7
-Your prepared branch: issue-7-8cea7add7a79
-Your prepared working directory: /tmp/gh-issue-solver-1766657756607
-Your forked repository: konard/tool2agent-tool2agent
-Original repository (upstream): tool2agent/tool2agent
-
-Proceed.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -92,7 +92,86 @@ function tool2agent<
 - AI SDK `tool()` does nothing and exists only for type checking, while `tool2agent()` builds the tool's `execute()` method
 - `tool()` passes exceptions through, while `tool2agent()` catches exceptions and returns them formatted nicely to the LLM as tool2agent `problems`
 - `tool2agent()` mandates input and output schemas. Use `never` / `z.never()` for output schema if it is not needed.
-- `tool2agent()` expects a json-serializable output type, and for this reason, it does not support providing custom `toModelOutput`
+- `tool2agent()` supports custom `toModelOutput` to transform tool results for the language model (see below)
+
+</details>
+
+### Custom `toModelOutput`
+
+By default, tool results are sent to the language model as JSON. You can customize this with `toModelOutput` to:
+
+- Convert results to plain text or YAML-like format
+- Include multipart responses with images/media
+- Provide cleaner, more readable output for the LLM
+
+<details>
+<summary><strong>Using <code>createToModelOutput</code></strong></summary>
+
+The `createToModelOutput` builder creates a `toModelOutput` function from renderers:
+
+```typescript
+import { tool2agent, createToModelOutput } from '@tool2agent/ai';
+
+const toModelOutput = createToModelOutput<InputType, OutputType>({
+  // Render successful outputs
+  renderOutput: output => ({
+    type: 'text',
+    value: `Result: ${output.name}`,
+  }),
+  // Optional: custom failure renderer
+  renderFailure: failure => ({
+    type: 'error-text',
+    value: `Error: ${JSON.stringify(failure.problems)}`,
+  }),
+});
+
+const tool = tool2agent({
+  inputSchema,
+  outputSchema,
+  execute: async input => ({ ok: true, ...result }),
+  toModelOutput,
+});
+```
+
+</details>
+
+<details>
+<summary><strong>Multipart responses with media</strong></summary>
+
+For tools that return images or other media:
+
+```typescript
+const toModelOutput = createToModelOutput<Input, Output>({
+  renderOutput: output => ({
+    type: 'content',
+    value: [
+      { type: 'text', text: `Screenshot: ${output.name}` },
+      { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
+    ],
+  }),
+});
+```
+
+Note: The library cannot automatically extract media from your output type. You must provide a custom renderer that knows how to unwrap media from your data structure.
+
+</details>
+
+<details>
+<summary><strong>Text-only output</strong></summary>
+
+Use `createTextToModelOutput` for simple text conversion:
+
+```typescript
+import { createTextToModelOutput, yamlLikeFormatter } from '@tool2agent/ai';
+
+// Default: JSON.stringify with formatting
+const toModelOutput = createTextToModelOutput<Input, Output>();
+
+// Custom formatter (e.g., YAML-like)
+const toModelOutput = createTextToModelOutput<Input, Output>({
+  formatOutput: yamlLikeFormatter,
+});
+```
 
 </details>
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -98,79 +98,47 @@ function tool2agent<
 
 ### Custom `toModelOutput`
 
-By default, tool results are sent to the language model as JSON. You can customize this with `toModelOutput` to:
-
-- Convert results to plain text or YAML-like format
-- Include multipart responses with images/media
-- Provide cleaner, more readable output for the LLM
-
-<details>
-<summary><strong>Using <code>createToModelOutput</code></strong></summary>
-
-The `createToModelOutput` builder creates a `toModelOutput` function from renderers:
+By default, tool results are sent to the language model as JSON. You can provide a custom `toModelOutput` function to convert results to plain text or a custom JSON format.
 
 ```typescript
-import { tool2agent, createToModelOutput } from '@tool2agent/ai';
-
-const toModelOutput = createToModelOutput<InputType, OutputType>({
-  // Render successful outputs
-  renderOutput: output => ({
-    type: 'text',
-    value: `Result: ${output.name}`,
-  }),
-  // Optional: custom failure renderer
-  renderFailure: failure => ({
-    type: 'error-text',
-    value: `Error: ${JSON.stringify(failure.problems)}`,
-  }),
-});
+import { tool2agent, createTextOutput } from '@tool2agent/ai';
 
 const tool = tool2agent({
   inputSchema,
   outputSchema,
-  execute: async input => ({ ok: true, ...result }),
-  toModelOutput,
-});
-```
-
-</details>
-
-<details>
-<summary><strong>Multipart responses with media</strong></summary>
-
-For tools that return images or other media:
-
-```typescript
-const toModelOutput = createToModelOutput<Input, Output>({
-  renderOutput: output => ({
-    type: 'content',
-    value: [
-      { type: 'text', text: `Screenshot: ${output.name}` },
-      { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
-    ],
+  execute: async input => ({ ok: true, result: 'success' }),
+  // Convert result to plain text
+  toModelOutput: createTextOutput(result => {
+    if (result.ok) {
+      return `Result: ${result.result}`;
+    }
+    return `Error: ${result.problems?.join(', ')}`;
   }),
 });
 ```
 
-Note: The library cannot automatically extract media from your output type. You must provide a custom renderer that knows how to unwrap media from your data structure.
-
-</details>
-
 <details>
-<summary><strong>Text-only output</strong></summary>
+<summary><strong>Available helpers</strong></summary>
 
-Use `createTextToModelOutput` for simple text conversion:
+- `createTextOutput(render)` - Creates a text output from a render function
+- `createJsonOutput(transform?)` - Creates a JSON output, optionally transforming the result
 
 ```typescript
-import { createTextToModelOutput, yamlLikeFormatter } from '@tool2agent/ai';
+import { createTextOutput, createJsonOutput } from '@tool2agent/ai';
 
-// Default: JSON.stringify with formatting
-const toModelOutput = createTextToModelOutput<Input, Output>();
-
-// Custom formatter (e.g., YAML-like)
-const toModelOutput = createTextToModelOutput<Input, Output>({
-  formatOutput: yamlLikeFormatter,
+// Text output
+const textOutput = createTextOutput<Input, Output>(result => {
+  if (result.ok) {
+    return `Success: ${JSON.stringify(result)}`;
+  }
+  return `Failed: ${result.problems?.join(', ')}`;
 });
+
+// JSON output with transformation
+const jsonOutput = createJsonOutput<Input, Output>(result => ({
+  success: result.ok,
+  data: result.ok ? result : null,
+}));
 ```
 
 </details>

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -18,18 +18,10 @@ export {
 } from './builder/types.js';
 export { createMiddleware, type Middleware, type MiddlewareOptions } from './middleware.js';
 export {
-  createToModelOutput,
-  createTextToModelOutput,
-  yamlLikeFormatter,
+  createTextOutput,
+  createJsonOutput,
   type ModelOutput,
   type ModelOutputText,
   type ModelOutputJson,
-  type ModelOutputErrorText,
-  type ModelOutputErrorJson,
-  type ModelOutputContent,
-  type ContentPartText,
-  type ContentPartMedia,
-  type OutputRenderer,
-  type FailureRenderer,
-  type CreateToModelOutputOptions,
+  type ToModelOutputFn,
 } from './to-model-output.js';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -17,3 +17,19 @@ export {
   type BuilderState,
 } from './builder/types.js';
 export { createMiddleware, type Middleware, type MiddlewareOptions } from './middleware.js';
+export {
+  createToModelOutput,
+  createTextToModelOutput,
+  yamlLikeFormatter,
+  type ModelOutput,
+  type ModelOutputText,
+  type ModelOutputJson,
+  type ModelOutputErrorText,
+  type ModelOutputErrorJson,
+  type ModelOutputContent,
+  type ContentPartText,
+  type ContentPartMedia,
+  type OutputRenderer,
+  type FailureRenderer,
+  type CreateToModelOutputOptions,
+} from './to-model-output.js';

--- a/packages/ai/src/to-model-output.ts
+++ b/packages/ai/src/to-model-output.ts
@@ -1,0 +1,373 @@
+import type { ToolCallResult, ToolCallSuccess, ToolCallFailure } from '@tool2agent/types';
+
+/**
+ * Text output for the language model.
+ */
+export type ModelOutputText = { type: 'text'; value: string };
+
+/**
+ * JSON output for the language model.
+ */
+export type ModelOutputJson = { type: 'json'; value: unknown };
+
+/**
+ * Error text output for the language model.
+ */
+export type ModelOutputErrorText = { type: 'error-text'; value: string };
+
+/**
+ * Error JSON output for the language model.
+ */
+export type ModelOutputErrorJson = { type: 'error-json'; value: unknown };
+
+/**
+ * Text content in a multipart model output.
+ */
+export type ContentPartText = { type: 'text'; text: string };
+
+/**
+ * Media content in a multipart model output.
+ */
+export type ContentPartMedia = {
+  type: 'media';
+  /** Base-64 encoded media data */
+  data: string;
+  /** IANA media type (e.g., 'image/png', 'image/jpeg') */
+  mediaType: string;
+};
+
+/**
+ * Multipart content output for the language model.
+ */
+export type ModelOutputContent = {
+  type: 'content';
+  value: Array<ContentPartText | ContentPartMedia>;
+};
+
+/**
+ * The output type that toModelOutput can return.
+ * This is compatible with the AI SDK's LanguageModelV2ToolResultPart['output'].
+ */
+export type ModelOutput =
+  | ModelOutputText
+  | ModelOutputJson
+  | ModelOutputErrorText
+  | ModelOutputErrorJson
+  | ModelOutputContent;
+
+/**
+ * A function that renders an OutputType to a model output.
+ * Can return various formats depending on the use case.
+ */
+export type OutputRenderer<OutputType> = (output: OutputType) => ModelOutput;
+
+/**
+ * A function that renders a failure result to a model output.
+ * If not provided, a default text representation will be used.
+ */
+export type FailureRenderer<InputType> = (failure: ToolCallFailure<InputType>) => ModelOutput;
+
+/**
+ * Options for creating a toModelOutput function.
+ */
+export type CreateToModelOutputOptions<InputType, OutputType> = {
+  /**
+   * Renderer for successful results.
+   * Takes the OutputType value from the success result.
+   * If not provided, falls back to JSON representation.
+   */
+  renderOutput?: OutputRenderer<OutputType>;
+  /**
+   * Renderer for failure results.
+   * If not provided, uses a default text representation of the failure.
+   */
+  renderFailure?: FailureRenderer<InputType>;
+  /**
+   * Whether to include feedback and instructions in the output.
+   * Default is true.
+   */
+  includeFeedback?: boolean;
+  /**
+   * Whether to include instructions in the output.
+   * Default is true.
+   */
+  includeInstructions?: boolean;
+};
+
+/**
+ * Extracts the output value from a ToolCallSuccess.
+ * Handles both record outputs (spread directly) and non-record outputs (wrapped in 'value').
+ */
+function extractOutputValue<OutputType>(
+  success: ToolCallSuccess<OutputType>,
+): OutputType | undefined {
+  // If there's a 'value' field, it's a non-record output
+  if ('value' in success) {
+    return success.value as OutputType;
+  }
+  // For record outputs, extract all non-metadata fields
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { ok, feedback, instructions, ...rest } = success;
+  return rest as unknown as OutputType;
+}
+
+/**
+ * Formats feedback and instructions as text lines.
+ */
+function formatFeedbackAndInstructions<InputType, OutputType>(
+  result: ToolCallResult<InputType, OutputType>,
+  options: { includeFeedback: boolean; includeInstructions: boolean },
+): string[] {
+  const lines: string[] = [];
+
+  if (options.includeFeedback && result.feedback?.length) {
+    lines.push('Feedback:');
+    for (const fb of result.feedback) {
+      lines.push(`  - ${fb}`);
+    }
+  }
+
+  if (options.includeInstructions && result.instructions?.length) {
+    lines.push('Instructions:');
+    for (const inst of result.instructions) {
+      lines.push(`  - ${inst}`);
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Default failure renderer that creates a text representation of the failure.
+ */
+function defaultFailureRenderer<InputType>(
+  failure: ToolCallFailure<InputType>,
+  options: { includeFeedback: boolean; includeInstructions: boolean },
+): ModelOutput {
+  const lines: string[] = ['Tool call failed.'];
+
+  // Handle record input failures with validationResults
+  if ('validationResults' in failure && failure.validationResults) {
+    lines.push('Validation results:');
+    for (const [param, result] of Object.entries(
+      failure.validationResults as Record<string, unknown>,
+    )) {
+      const paramResult = result as {
+        valid: boolean;
+        problems?: string[];
+        suggestedValues?: unknown[];
+        allowedValues?: unknown[];
+      };
+      if (!paramResult.valid) {
+        lines.push(`  ${param}:`);
+        if (paramResult.problems?.length) {
+          for (const problem of paramResult.problems) {
+            lines.push(`    - ${problem}`);
+          }
+        }
+        if (paramResult.suggestedValues?.length) {
+          lines.push(`    Suggested values: ${JSON.stringify(paramResult.suggestedValues)}`);
+        }
+        if (paramResult.allowedValues) {
+          lines.push(`    Allowed values: ${JSON.stringify(paramResult.allowedValues)}`);
+        }
+      }
+    }
+  }
+
+  // Handle problems at the top level
+  if ('problems' in failure && failure.problems?.length) {
+    lines.push('Problems:');
+    for (const problem of failure.problems) {
+      lines.push(`  - ${problem}`);
+    }
+  }
+
+  // Add feedback and instructions
+  lines.push(
+    ...formatFeedbackAndInstructions(failure as ToolCallResult<InputType, never>, options),
+  );
+
+  return { type: 'text', value: lines.join('\n') };
+}
+
+/**
+ * Creates a toModelOutput function that converts ToolCallResult to a model-consumable format.
+ *
+ * This is a builder function that takes renderers for output and failure cases
+ * and produces a function compatible with AI SDK's toModelOutput.
+ *
+ * @example
+ * ```typescript
+ * // Simple text renderer
+ * const toModelOutput = createToModelOutput<Input, Output>({
+ *   renderOutput: (output) => ({ type: 'text', value: `Result: ${output.name}` }),
+ * });
+ *
+ * // With multipart content including images
+ * const toModelOutput = createToModelOutput<Input, Output>({
+ *   renderOutput: (output) => ({
+ *     type: 'content',
+ *     value: [
+ *       { type: 'text', text: `Found: ${output.name}` },
+ *       { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
+ *     ],
+ *   }),
+ * });
+ * ```
+ */
+export function createToModelOutput<InputType, OutputType>(
+  options: CreateToModelOutputOptions<InputType, OutputType> = {},
+): (output: ToolCallResult<InputType, OutputType>) => ModelOutput {
+  const {
+    renderOutput,
+    renderFailure,
+    includeFeedback = true,
+    includeInstructions = true,
+  } = options;
+
+  return (result: ToolCallResult<InputType, OutputType>): ModelOutput => {
+    if (result.ok) {
+      // Success case
+      const outputValue = extractOutputValue(result);
+
+      if (renderOutput && outputValue !== undefined) {
+        const rendered = renderOutput(outputValue);
+
+        // If feedback/instructions are enabled, append them for text outputs
+        if (
+          (includeFeedback || includeInstructions) &&
+          (result.feedback?.length || result.instructions?.length)
+        ) {
+          const feedbackLines = formatFeedbackAndInstructions(result, {
+            includeFeedback,
+            includeInstructions,
+          });
+
+          if (feedbackLines.length > 0) {
+            if (rendered.type === 'text') {
+              return {
+                type: 'text',
+                value: rendered.value + '\n\n' + feedbackLines.join('\n'),
+              };
+            }
+            if (rendered.type === 'content') {
+              return {
+                type: 'content',
+                value: [...rendered.value, { type: 'text', text: '\n' + feedbackLines.join('\n') }],
+              };
+            }
+          }
+        }
+
+        return rendered;
+      }
+
+      // Default: JSON representation for success
+      return { type: 'json', value: result as unknown };
+    } else {
+      // Failure case
+      if (renderFailure) {
+        return renderFailure(result);
+      }
+
+      return defaultFailureRenderer(result, { includeFeedback, includeInstructions });
+    }
+  };
+}
+
+/**
+ * Creates a simple text-based toModelOutput function.
+ * Converts the entire ToolCallResult to a formatted text string.
+ *
+ * This is useful when you want to replace JSON representation with plain text.
+ *
+ * @example
+ * ```typescript
+ * const tool = tool2agent({
+ *   // ...
+ *   toModelOutput: createTextToModelOutput(),
+ * });
+ * ```
+ */
+export function createTextToModelOutput<InputType, OutputType>(options?: {
+  /**
+   * Custom formatter for the output value.
+   * Default uses JSON.stringify with formatting.
+   */
+  formatOutput?: (output: OutputType) => string;
+  includeFeedback?: boolean;
+  includeInstructions?: boolean;
+}): (output: ToolCallResult<InputType, OutputType>) => ModelOutput {
+  const formatOutput = options?.formatOutput ?? ((o: OutputType) => JSON.stringify(o, null, 2));
+
+  return createToModelOutput<InputType, OutputType>({
+    renderOutput: output => ({ type: 'text', value: formatOutput(output) }),
+    includeFeedback: options?.includeFeedback,
+    includeInstructions: options?.includeInstructions,
+  });
+}
+
+/**
+ * Pre-built renderer that formats output as YAML-like text.
+ * This is a simple implementation that works for basic objects.
+ *
+ * @example
+ * ```typescript
+ * const tool = tool2agent({
+ *   // ...
+ *   toModelOutput: createTextToModelOutput({
+ *     formatOutput: yamlLikeFormatter,
+ *   }),
+ * });
+ * ```
+ */
+export function yamlLikeFormatter(value: unknown, indent = 0): string {
+  const prefix = '  '.repeat(indent);
+
+  if (value === null || value === undefined) {
+    return `${prefix}null`;
+  }
+
+  if (typeof value === 'string') {
+    // Multi-line strings use block scalar
+    if (value.includes('\n')) {
+      return `${prefix}|\n${value
+        .split('\n')
+        .map(line => `${prefix}  ${line}`)
+        .join('\n')}`;
+    }
+    return `${prefix}${value}`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return `${prefix}${value}`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return `${prefix}[]`;
+    }
+    return value.map(item => `${prefix}- ${yamlLikeFormatter(item, 0).trim()}`).join('\n');
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return `${prefix}{}`;
+    }
+    return entries
+      .map(([key, val]) => {
+        const formattedVal = yamlLikeFormatter(val, indent + 1);
+        if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+          return `${prefix}${key}:\n${formattedVal}`;
+        }
+        return `${prefix}${key}: ${formattedVal.trim()}`;
+      })
+      .join('\n');
+  }
+
+  // Fallback for any other types (symbols, functions, etc.)
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return `${prefix}${String(value)}`;
+}

--- a/packages/ai/src/to-model-output.ts
+++ b/packages/ai/src/to-model-output.ts
@@ -1,4 +1,4 @@
-import type { ToolCallResult, ToolCallSuccess, ToolCallFailure } from '@tool2agent/types';
+import type { ToolCallResult } from '@tool2agent/types';
 
 /**
  * Text output for the language model.
@@ -11,363 +11,75 @@ export type ModelOutputText = { type: 'text'; value: string };
 export type ModelOutputJson = { type: 'json'; value: unknown };
 
 /**
- * Error text output for the language model.
- */
-export type ModelOutputErrorText = { type: 'error-text'; value: string };
-
-/**
- * Error JSON output for the language model.
- */
-export type ModelOutputErrorJson = { type: 'error-json'; value: unknown };
-
-/**
- * Text content in a multipart model output.
- */
-export type ContentPartText = { type: 'text'; text: string };
-
-/**
- * Media content in a multipart model output.
- */
-export type ContentPartMedia = {
-  type: 'media';
-  /** Base-64 encoded media data */
-  data: string;
-  /** IANA media type (e.g., 'image/png', 'image/jpeg') */
-  mediaType: string;
-};
-
-/**
- * Multipart content output for the language model.
- */
-export type ModelOutputContent = {
-  type: 'content';
-  value: Array<ContentPartText | ContentPartMedia>;
-};
-
-/**
  * The output type that toModelOutput can return.
- * This is compatible with the AI SDK's LanguageModelV2ToolResultPart['output'].
+ * Supports plain text and JSON only.
  */
-export type ModelOutput =
-  | ModelOutputText
-  | ModelOutputJson
-  | ModelOutputErrorText
-  | ModelOutputErrorJson
-  | ModelOutputContent;
+export type ModelOutput = ModelOutputText | ModelOutputJson;
 
 /**
- * A function that renders an OutputType to a model output.
- * Can return various formats depending on the use case.
+ * A function that converts a ToolCallResult to a model output.
+ * This is the type signature for the toModelOutput parameter of tool2agent.
  */
-export type OutputRenderer<OutputType> = (output: OutputType) => ModelOutput;
-
-/**
- * A function that renders a failure result to a model output.
- * If not provided, a default text representation will be used.
- */
-export type FailureRenderer<InputType> = (failure: ToolCallFailure<InputType>) => ModelOutput;
-
-/**
- * Options for creating a toModelOutput function.
- */
-export type CreateToModelOutputOptions<InputType, OutputType> = {
-  /**
-   * Renderer for successful results.
-   * Takes the OutputType value from the success result.
-   * If not provided, falls back to JSON representation.
-   */
-  renderOutput?: OutputRenderer<OutputType>;
-  /**
-   * Renderer for failure results.
-   * If not provided, uses a default text representation of the failure.
-   */
-  renderFailure?: FailureRenderer<InputType>;
-  /**
-   * Whether to include feedback and instructions in the output.
-   * Default is true.
-   */
-  includeFeedback?: boolean;
-  /**
-   * Whether to include instructions in the output.
-   * Default is true.
-   */
-  includeInstructions?: boolean;
-};
-
-/**
- * Extracts the output value from a ToolCallSuccess.
- * Handles both record outputs (spread directly) and non-record outputs (wrapped in 'value').
- */
-function extractOutputValue<OutputType>(
-  success: ToolCallSuccess<OutputType>,
-): OutputType | undefined {
-  // If there's a 'value' field, it's a non-record output
-  if ('value' in success) {
-    return success.value as OutputType;
-  }
-  // For record outputs, extract all non-metadata fields
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { ok, feedback, instructions, ...rest } = success;
-  return rest as unknown as OutputType;
-}
-
-/**
- * Formats feedback and instructions as text lines.
- */
-function formatFeedbackAndInstructions<InputType, OutputType>(
+export type ToModelOutputFn<InputType, OutputType> = (
   result: ToolCallResult<InputType, OutputType>,
-  options: { includeFeedback: boolean; includeInstructions: boolean },
-): string[] {
-  const lines: string[] = [];
-
-  if (options.includeFeedback && result.feedback?.length) {
-    lines.push('Feedback:');
-    for (const fb of result.feedback) {
-      lines.push(`  - ${fb}`);
-    }
-  }
-
-  if (options.includeInstructions && result.instructions?.length) {
-    lines.push('Instructions:');
-    for (const inst of result.instructions) {
-      lines.push(`  - ${inst}`);
-    }
-  }
-
-  return lines;
-}
+) => ModelOutput;
 
 /**
- * Default failure renderer that creates a text representation of the failure.
- */
-function defaultFailureRenderer<InputType>(
-  failure: ToolCallFailure<InputType>,
-  options: { includeFeedback: boolean; includeInstructions: boolean },
-): ModelOutput {
-  const lines: string[] = ['Tool call failed.'];
-
-  // Handle record input failures with validationResults
-  if ('validationResults' in failure && failure.validationResults) {
-    lines.push('Validation results:');
-    for (const [param, result] of Object.entries(
-      failure.validationResults as Record<string, unknown>,
-    )) {
-      const paramResult = result as {
-        valid: boolean;
-        problems?: string[];
-        suggestedValues?: unknown[];
-        allowedValues?: unknown[];
-      };
-      if (!paramResult.valid) {
-        lines.push(`  ${param}:`);
-        if (paramResult.problems?.length) {
-          for (const problem of paramResult.problems) {
-            lines.push(`    - ${problem}`);
-          }
-        }
-        if (paramResult.suggestedValues?.length) {
-          lines.push(`    Suggested values: ${JSON.stringify(paramResult.suggestedValues)}`);
-        }
-        if (paramResult.allowedValues) {
-          lines.push(`    Allowed values: ${JSON.stringify(paramResult.allowedValues)}`);
-        }
-      }
-    }
-  }
-
-  // Handle problems at the top level
-  if ('problems' in failure && failure.problems?.length) {
-    lines.push('Problems:');
-    for (const problem of failure.problems) {
-      lines.push(`  - ${problem}`);
-    }
-  }
-
-  // Add feedback and instructions
-  lines.push(
-    ...formatFeedbackAndInstructions(failure as ToolCallResult<InputType, never>, options),
-  );
-
-  return { type: 'text', value: lines.join('\n') };
-}
-
-/**
- * Creates a toModelOutput function that converts ToolCallResult to a model-consumable format.
+ * Creates a toModelOutput function that converts ToolCallResult to text format.
+ * This is a simple builder for text-based output.
  *
- * This is a builder function that takes renderers for output and failure cases
- * and produces a function compatible with AI SDK's toModelOutput.
- *
- * @example
- * ```typescript
- * // Simple text renderer
- * const toModelOutput = createToModelOutput<Input, Output>({
- *   renderOutput: (output) => ({ type: 'text', value: `Result: ${output.name}` }),
- * });
- *
- * // With multipart content including images
- * const toModelOutput = createToModelOutput<Input, Output>({
- *   renderOutput: (output) => ({
- *     type: 'content',
- *     value: [
- *       { type: 'text', text: `Found: ${output.name}` },
- *       { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
- *     ],
- *   }),
- * });
- * ```
- */
-export function createToModelOutput<InputType, OutputType>(
-  options: CreateToModelOutputOptions<InputType, OutputType> = {},
-): (output: ToolCallResult<InputType, OutputType>) => ModelOutput {
-  const {
-    renderOutput,
-    renderFailure,
-    includeFeedback = true,
-    includeInstructions = true,
-  } = options;
-
-  return (result: ToolCallResult<InputType, OutputType>): ModelOutput => {
-    if (result.ok) {
-      // Success case
-      const outputValue = extractOutputValue(result);
-
-      if (renderOutput && outputValue !== undefined) {
-        const rendered = renderOutput(outputValue);
-
-        // If feedback/instructions are enabled, append them for text outputs
-        if (
-          (includeFeedback || includeInstructions) &&
-          (result.feedback?.length || result.instructions?.length)
-        ) {
-          const feedbackLines = formatFeedbackAndInstructions(result, {
-            includeFeedback,
-            includeInstructions,
-          });
-
-          if (feedbackLines.length > 0) {
-            if (rendered.type === 'text') {
-              return {
-                type: 'text',
-                value: rendered.value + '\n\n' + feedbackLines.join('\n'),
-              };
-            }
-            if (rendered.type === 'content') {
-              return {
-                type: 'content',
-                value: [...rendered.value, { type: 'text', text: '\n' + feedbackLines.join('\n') }],
-              };
-            }
-          }
-        }
-
-        return rendered;
-      }
-
-      // Default: JSON representation for success
-      return { type: 'json', value: result as unknown };
-    } else {
-      // Failure case
-      if (renderFailure) {
-        return renderFailure(result);
-      }
-
-      return defaultFailureRenderer(result, { includeFeedback, includeInstructions });
-    }
-  };
-}
-
-/**
- * Creates a simple text-based toModelOutput function.
- * Converts the entire ToolCallResult to a formatted text string.
- *
- * This is useful when you want to replace JSON representation with plain text.
+ * @param render - A function that takes the ToolCallResult and returns a string
+ * @returns A toModelOutput function compatible with tool2agent
  *
  * @example
  * ```typescript
  * const tool = tool2agent({
- *   // ...
- *   toModelOutput: createTextToModelOutput(),
+ *   inputSchema,
+ *   outputSchema,
+ *   execute: async (input) => ({ ok: true, result: 'success' }),
+ *   toModelOutput: createTextOutput(result => {
+ *     if (result.ok) {
+ *       return `Result: ${result.result}`;
+ *     }
+ *     return `Error: ${result.problems?.join(', ')}`;
+ *   }),
  * });
  * ```
  */
-export function createTextToModelOutput<InputType, OutputType>(options?: {
-  /**
-   * Custom formatter for the output value.
-   * Default uses JSON.stringify with formatting.
-   */
-  formatOutput?: (output: OutputType) => string;
-  includeFeedback?: boolean;
-  includeInstructions?: boolean;
-}): (output: ToolCallResult<InputType, OutputType>) => ModelOutput {
-  const formatOutput = options?.formatOutput ?? ((o: OutputType) => JSON.stringify(o, null, 2));
-
-  return createToModelOutput<InputType, OutputType>({
-    renderOutput: output => ({ type: 'text', value: formatOutput(output) }),
-    includeFeedback: options?.includeFeedback,
-    includeInstructions: options?.includeInstructions,
+export function createTextOutput<InputType, OutputType>(
+  render: (result: ToolCallResult<InputType, OutputType>) => string,
+): ToModelOutputFn<InputType, OutputType> {
+  return (result: ToolCallResult<InputType, OutputType>): ModelOutput => ({
+    type: 'text',
+    value: render(result),
   });
 }
 
 /**
- * Pre-built renderer that formats output as YAML-like text.
- * This is a simple implementation that works for basic objects.
+ * Creates a toModelOutput function that converts ToolCallResult to JSON format.
+ * This is the default behavior if no toModelOutput is provided.
+ *
+ * @param transform - Optional function to transform the result before JSON serialization
+ * @returns A toModelOutput function compatible with tool2agent
  *
  * @example
  * ```typescript
  * const tool = tool2agent({
- *   // ...
- *   toModelOutput: createTextToModelOutput({
- *     formatOutput: yamlLikeFormatter,
- *   }),
+ *   inputSchema,
+ *   outputSchema,
+ *   execute: async (input) => ({ ok: true, result: 'success' }),
+ *   toModelOutput: createJsonOutput(result => ({
+ *     success: result.ok,
+ *     data: result.ok ? result : null,
+ *   })),
  * });
  * ```
  */
-export function yamlLikeFormatter(value: unknown, indent = 0): string {
-  const prefix = '  '.repeat(indent);
-
-  if (value === null || value === undefined) {
-    return `${prefix}null`;
-  }
-
-  if (typeof value === 'string') {
-    // Multi-line strings use block scalar
-    if (value.includes('\n')) {
-      return `${prefix}|\n${value
-        .split('\n')
-        .map(line => `${prefix}  ${line}`)
-        .join('\n')}`;
-    }
-    return `${prefix}${value}`;
-  }
-
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return `${prefix}${value}`;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return `${prefix}[]`;
-    }
-    return value.map(item => `${prefix}- ${yamlLikeFormatter(item, 0).trim()}`).join('\n');
-  }
-
-  if (typeof value === 'object') {
-    const entries = Object.entries(value);
-    if (entries.length === 0) {
-      return `${prefix}{}`;
-    }
-    return entries
-      .map(([key, val]) => {
-        const formattedVal = yamlLikeFormatter(val, indent + 1);
-        if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
-          return `${prefix}${key}:\n${formattedVal}`;
-        }
-        return `${prefix}${key}: ${formattedVal.trim()}`;
-      })
-      .join('\n');
-  }
-
-  // Fallback for any other types (symbols, functions, etc.)
-  // eslint-disable-next-line @typescript-eslint/no-base-to-string
-  return `${prefix}${String(value)}`;
+export function createJsonOutput<InputType, OutputType>(
+  transform?: (result: ToolCallResult<InputType, OutputType>) => unknown,
+): ToModelOutputFn<InputType, OutputType> {
+  return (result: ToolCallResult<InputType, OutputType>): ModelOutput => ({
+    type: 'json',
+    value: transform ? transform(result) : result,
+  });
 }

--- a/packages/ai/test/to-model-output.test.ts
+++ b/packages/ai/test/to-model-output.test.ts
@@ -1,11 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { z } from 'zod';
-import {
-  createToModelOutput,
-  createTextToModelOutput,
-  yamlLikeFormatter,
-} from '../src/to-model-output.js';
+import { createTextOutput, createJsonOutput } from '../src/to-model-output.js';
 import { tool2agent } from '../src/tool2agent.js';
 import type { ToolCallResult } from '@tool2agent/types';
 
@@ -13,13 +9,13 @@ type TestInput = { query: string };
 type TestOutput = { result: string; count: number };
 
 describe('toModelOutput utilities', () => {
-  describe('createToModelOutput', () => {
-    it('converts success result to custom text output', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
-        renderOutput: output => ({
-          type: 'text',
-          value: `Found ${output.count} results: ${output.result}`,
-        }),
+  describe('createTextOutput', () => {
+    it('converts success result to text output', () => {
+      const toModelOutput = createTextOutput<TestInput, TestOutput>(result => {
+        if (result.ok) {
+          return `Found ${result.count} results: ${result.result}`;
+        }
+        return 'Failed';
       });
 
       const successResult: ToolCallResult<TestInput, TestOutput> = {
@@ -35,32 +31,39 @@ describe('toModelOutput utilities', () => {
       });
     });
 
-    it('converts success result with value field (non-record output)', () => {
-      const toModelOutput = createToModelOutput<TestInput, string>({
-        renderOutput: output => ({
-          type: 'text',
-          value: `Result: ${output}`,
-        }),
+    it('converts failure result to text output', () => {
+      const toModelOutput = createTextOutput<TestInput, TestOutput>(result => {
+        if (result.ok) {
+          return `Success: ${result.result}`;
+        }
+        return `Error: ${result.problems?.join(', ') ?? 'Unknown error'}`;
       });
 
-      const successResult: ToolCallResult<TestInput, string> = {
-        ok: true,
-        value: 'simple string result',
+      const failureResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: false,
+        problems: ['Query is too short', 'Invalid format'],
       };
 
-      const output = toModelOutput(successResult);
+      const output = toModelOutput(failureResult);
       expect(output).to.deep.equal({
         type: 'text',
-        value: 'Result: simple string result',
+        value: 'Error: Query is too short, Invalid format',
       });
     });
 
-    it('appends feedback and instructions to text output', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
-        renderOutput: output => ({
-          type: 'text',
-          value: `Count: ${output.count}`,
-        }),
+    it('handles result with feedback and instructions', () => {
+      const toModelOutput = createTextOutput<TestInput, TestOutput>(result => {
+        const lines: string[] = [];
+        if (result.ok) {
+          lines.push(`Count: ${result.count}`);
+        }
+        if (result.feedback?.length) {
+          lines.push(`Feedback: ${result.feedback.join(', ')}`);
+        }
+        if (result.instructions?.length) {
+          lines.push(`Instructions: ${result.instructions.join(', ')}`);
+        }
+        return lines.join('\n');
       });
 
       const successResult: ToolCallResult<TestInput, TestOutput> = {
@@ -75,158 +78,15 @@ describe('toModelOutput utilities', () => {
       expect(output.type).to.equal('text');
       if (output.type === 'text') {
         expect(output.value).to.include('Count: 5');
-        expect(output.value).to.include('Feedback:');
-        expect(output.value).to.include('Good job!');
-        expect(output.value).to.include('Instructions:');
-        expect(output.value).to.include('Continue with next step');
-      }
-    });
-
-    it('appends feedback to content output', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
-        renderOutput: output => ({
-          type: 'content',
-          value: [{ type: 'text', text: `Count: ${output.count}` }],
-        }),
-      });
-
-      const successResult: ToolCallResult<TestInput, TestOutput> = {
-        ok: true,
-        result: 'test',
-        count: 5,
-        feedback: ['Important info'],
-      };
-
-      const output = toModelOutput(successResult);
-      expect(output.type).to.equal('content');
-      if (output.type === 'content') {
-        expect(output.value).to.have.lengthOf(2);
-        expect(output.value[0]).to.deep.equal({ type: 'text', text: 'Count: 5' });
-        expect(output.value[1]).to.have.property('type', 'text');
-        expect((output.value[1] as { type: 'text'; text: string }).text).to.include(
-          'Important info',
-        );
-      }
-    });
-
-    it('excludes feedback when includeFeedback is false', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
-        renderOutput: output => ({
-          type: 'text',
-          value: `Count: ${output.count}`,
-        }),
-        includeFeedback: false,
-      });
-
-      const successResult: ToolCallResult<TestInput, TestOutput> = {
-        ok: true,
-        result: 'test',
-        count: 5,
-        feedback: ['Should not appear'],
-      };
-
-      const output = toModelOutput(successResult);
-      expect(output.type).to.equal('text');
-      if (output.type === 'text') {
-        expect(output.value).to.not.include('Should not appear');
-      }
-    });
-
-    it('converts failure result with default renderer', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({});
-
-      const failureResult: ToolCallResult<TestInput, TestOutput> = {
-        ok: false,
-        validationResults: {
-          query: {
-            valid: false,
-            problems: ['Query is too short'],
-            suggestedValues: ['search term', 'another term'],
-          },
-        },
-      };
-
-      const output = toModelOutput(failureResult);
-      expect(output.type).to.equal('text');
-      if (output.type === 'text') {
-        expect(output.value).to.include('Tool call failed');
-        expect(output.value).to.include('query');
-        expect(output.value).to.include('Query is too short');
-        expect(output.value).to.include('Suggested values');
-      }
-    });
-
-    it('converts failure with top-level problems', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({});
-
-      const failureResult: ToolCallResult<TestInput, TestOutput> = {
-        ok: false,
-        problems: ['General error occurred', 'Another problem'],
-      };
-
-      const output = toModelOutput(failureResult);
-      expect(output.type).to.equal('text');
-      if (output.type === 'text') {
-        expect(output.value).to.include('General error occurred');
-        expect(output.value).to.include('Another problem');
-      }
-    });
-
-    it('uses custom failure renderer when provided', () => {
-      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
-        renderFailure: failure => ({
-          type: 'error-text',
-          value: `Custom failure: ${JSON.stringify(failure)}`,
-        }),
-      });
-
-      const failureResult: ToolCallResult<TestInput, TestOutput> = {
-        ok: false,
-        problems: ['Some error'],
-      };
-
-      const output = toModelOutput(failureResult);
-      expect(output.type).to.equal('error-text');
-      if (output.type === 'error-text') {
-        expect(output.value).to.include('Custom failure');
-        expect(output.value).to.include('Some error');
-      }
-    });
-
-    it('supports multipart content with media', () => {
-      type OutputWithImage = { name: string; imageBase64: string };
-
-      const toModelOutput = createToModelOutput<TestInput, OutputWithImage>({
-        renderOutput: output => ({
-          type: 'content',
-          value: [
-            { type: 'text', text: `Image: ${output.name}` },
-            { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
-          ],
-        }),
-      });
-
-      const successResult: ToolCallResult<TestInput, OutputWithImage> = {
-        ok: true,
-        name: 'screenshot.png',
-        imageBase64:
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-      };
-
-      const output = toModelOutput(successResult);
-      expect(output.type).to.equal('content');
-      if (output.type === 'content') {
-        expect(output.value).to.have.lengthOf(2);
-        expect(output.value[0]).to.deep.equal({ type: 'text', text: 'Image: screenshot.png' });
-        expect(output.value[1]).to.have.property('type', 'media');
-        expect(output.value[1]).to.have.property('mediaType', 'image/png');
+        expect(output.value).to.include('Feedback: Good job!');
+        expect(output.value).to.include('Instructions: Continue with next step');
       }
     });
   });
 
-  describe('createTextToModelOutput', () => {
-    it('converts success result to formatted text', () => {
-      const toModelOutput = createTextToModelOutput<TestInput, TestOutput>();
+  describe('createJsonOutput', () => {
+    it('returns result as JSON without transformation', () => {
+      const toModelOutput = createJsonOutput<TestInput, TestOutput>();
 
       const successResult: ToolCallResult<TestInput, TestOutput> = {
         ok: true,
@@ -235,19 +95,17 @@ describe('toModelOutput utilities', () => {
       };
 
       const output = toModelOutput(successResult);
-      expect(output.type).to.equal('text');
-      if (output.type === 'text') {
-        // Default uses JSON.stringify with formatting
-        expect(output.value).to.include('"result"');
-        expect(output.value).to.include('"count"');
-        expect(output.value).to.include('10');
-      }
+      expect(output).to.deep.equal({
+        type: 'json',
+        value: successResult,
+      });
     });
 
-    it('uses custom formatter', () => {
-      const toModelOutput = createTextToModelOutput<TestInput, TestOutput>({
-        formatOutput: output => `Result=${output.result}, Count=${output.count}`,
-      });
+    it('transforms result when transform function is provided', () => {
+      const toModelOutput = createJsonOutput<TestInput, TestOutput>(result => ({
+        success: result.ok,
+        data: result.ok ? { result: result.result, count: result.count } : null,
+      }));
 
       const successResult: ToolCallResult<TestInput, TestOutput> = {
         ok: true,
@@ -256,53 +114,34 @@ describe('toModelOutput utilities', () => {
       };
 
       const output = toModelOutput(successResult);
-      expect(output.type).to.equal('text');
-      if (output.type === 'text') {
-        expect(output.value).to.equal('Result=test, Count=5');
-      }
-    });
-  });
-
-  describe('yamlLikeFormatter', () => {
-    it('formats primitive values', () => {
-      expect(yamlLikeFormatter('hello')).to.equal('hello');
-      expect(yamlLikeFormatter(42)).to.equal('42');
-      expect(yamlLikeFormatter(true)).to.equal('true');
-      expect(yamlLikeFormatter(null)).to.equal('null');
-    });
-
-    it('formats simple objects', () => {
-      const result = yamlLikeFormatter({ name: 'test', count: 5 });
-      expect(result).to.include('name: test');
-      expect(result).to.include('count: 5');
-    });
-
-    it('formats arrays', () => {
-      const result = yamlLikeFormatter(['a', 'b', 'c']);
-      expect(result).to.include('- a');
-      expect(result).to.include('- b');
-      expect(result).to.include('- c');
-    });
-
-    it('formats nested objects', () => {
-      const result = yamlLikeFormatter({
-        user: { name: 'John', age: 30 },
+      expect(output).to.deep.equal({
+        type: 'json',
+        value: {
+          success: true,
+          data: { result: 'test', count: 5 },
+        },
       });
-      expect(result).to.include('user:');
-      expect(result).to.include('name: John');
-      expect(result).to.include('age: 30');
     });
 
-    it('formats empty objects and arrays', () => {
-      expect(yamlLikeFormatter({})).to.equal('{}');
-      expect(yamlLikeFormatter([])).to.equal('[]');
-    });
+    it('handles failure result with transformation', () => {
+      const toModelOutput = createJsonOutput<TestInput, TestOutput>(result => ({
+        success: result.ok,
+        errors: result.ok ? null : result.problems,
+      }));
 
-    it('handles multi-line strings', () => {
-      const result = yamlLikeFormatter('line1\nline2\nline3');
-      expect(result).to.include('|');
-      expect(result).to.include('line1');
-      expect(result).to.include('line2');
+      const failureResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: false,
+        problems: ['Error 1', 'Error 2'],
+      };
+
+      const output = toModelOutput(failureResult);
+      expect(output).to.deep.equal({
+        type: 'json',
+        value: {
+          success: false,
+          errors: ['Error 1', 'Error 2'],
+        },
+      });
     });
   });
 
@@ -311,14 +150,14 @@ describe('toModelOutput utilities', () => {
       const inputSchema = z.object({ query: z.string() });
       const outputSchema = z.object({ result: z.string() });
 
-      const toModelOutput = createToModelOutput<
+      const toModelOutput = createTextOutput<
         z.infer<typeof inputSchema>,
         z.infer<typeof outputSchema>
-      >({
-        renderOutput: output => ({
-          type: 'text',
-          value: `Search result: ${output.result}`,
-        }),
+      >(result => {
+        if (result.ok) {
+          return `Search result: ${result.result}`;
+        }
+        return `Error: ${result.problems?.join(', ')}`;
       });
 
       const tool = tool2agent({
@@ -344,6 +183,43 @@ describe('toModelOutput utilities', () => {
         expect(modelOutput.type).to.equal('text');
         if (modelOutput.type === 'text') {
           expect(modelOutput.value).to.equal('Search result: Found: test');
+        }
+      }
+    });
+
+    it('works with createJsonOutput', async () => {
+      const inputSchema = z.object({ id: z.number() });
+      const outputSchema = z.object({ name: z.string() });
+
+      const toModelOutput = createJsonOutput<
+        z.infer<typeof inputSchema>,
+        z.infer<typeof outputSchema>
+      >(result => ({
+        status: result.ok ? 'success' : 'error',
+        payload: result.ok ? { name: result.name } : null,
+      }));
+
+      const tool = tool2agent({
+        inputSchema,
+        outputSchema,
+        execute: async input => ({
+          ok: true as const,
+          name: `Item ${input.id}`,
+        }),
+        toModelOutput,
+      });
+
+      const result = await tool.execute({ id: 42 }, { toolCallId: 'test', messages: [] });
+      expect(result.ok).to.be.true;
+
+      if (tool.toModelOutput) {
+        const modelOutput = tool.toModelOutput(result);
+        expect(modelOutput.type).to.equal('json');
+        if (modelOutput.type === 'json') {
+          expect(modelOutput.value).to.deep.equal({
+            status: 'success',
+            payload: { name: 'Item 42' },
+          });
         }
       }
     });

--- a/packages/ai/test/to-model-output.test.ts
+++ b/packages/ai/test/to-model-output.test.ts
@@ -1,0 +1,351 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { z } from 'zod';
+import {
+  createToModelOutput,
+  createTextToModelOutput,
+  yamlLikeFormatter,
+} from '../src/to-model-output.js';
+import { tool2agent } from '../src/tool2agent.js';
+import type { ToolCallResult } from '@tool2agent/types';
+
+type TestInput = { query: string };
+type TestOutput = { result: string; count: number };
+
+describe('toModelOutput utilities', () => {
+  describe('createToModelOutput', () => {
+    it('converts success result to custom text output', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
+        renderOutput: output => ({
+          type: 'text',
+          value: `Found ${output.count} results: ${output.result}`,
+        }),
+      });
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'test data',
+        count: 42,
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output).to.deep.equal({
+        type: 'text',
+        value: 'Found 42 results: test data',
+      });
+    });
+
+    it('converts success result with value field (non-record output)', () => {
+      const toModelOutput = createToModelOutput<TestInput, string>({
+        renderOutput: output => ({
+          type: 'text',
+          value: `Result: ${output}`,
+        }),
+      });
+
+      const successResult: ToolCallResult<TestInput, string> = {
+        ok: true,
+        value: 'simple string result',
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output).to.deep.equal({
+        type: 'text',
+        value: 'Result: simple string result',
+      });
+    });
+
+    it('appends feedback and instructions to text output', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
+        renderOutput: output => ({
+          type: 'text',
+          value: `Count: ${output.count}`,
+        }),
+      });
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'test',
+        count: 5,
+        feedback: ['Good job!'],
+        instructions: ['Continue with next step'],
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        expect(output.value).to.include('Count: 5');
+        expect(output.value).to.include('Feedback:');
+        expect(output.value).to.include('Good job!');
+        expect(output.value).to.include('Instructions:');
+        expect(output.value).to.include('Continue with next step');
+      }
+    });
+
+    it('appends feedback to content output', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
+        renderOutput: output => ({
+          type: 'content',
+          value: [{ type: 'text', text: `Count: ${output.count}` }],
+        }),
+      });
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'test',
+        count: 5,
+        feedback: ['Important info'],
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('content');
+      if (output.type === 'content') {
+        expect(output.value).to.have.lengthOf(2);
+        expect(output.value[0]).to.deep.equal({ type: 'text', text: 'Count: 5' });
+        expect(output.value[1]).to.have.property('type', 'text');
+        expect((output.value[1] as { type: 'text'; text: string }).text).to.include(
+          'Important info',
+        );
+      }
+    });
+
+    it('excludes feedback when includeFeedback is false', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
+        renderOutput: output => ({
+          type: 'text',
+          value: `Count: ${output.count}`,
+        }),
+        includeFeedback: false,
+      });
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'test',
+        count: 5,
+        feedback: ['Should not appear'],
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        expect(output.value).to.not.include('Should not appear');
+      }
+    });
+
+    it('converts failure result with default renderer', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({});
+
+      const failureResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: false,
+        validationResults: {
+          query: {
+            valid: false,
+            problems: ['Query is too short'],
+            suggestedValues: ['search term', 'another term'],
+          },
+        },
+      };
+
+      const output = toModelOutput(failureResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        expect(output.value).to.include('Tool call failed');
+        expect(output.value).to.include('query');
+        expect(output.value).to.include('Query is too short');
+        expect(output.value).to.include('Suggested values');
+      }
+    });
+
+    it('converts failure with top-level problems', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({});
+
+      const failureResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: false,
+        problems: ['General error occurred', 'Another problem'],
+      };
+
+      const output = toModelOutput(failureResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        expect(output.value).to.include('General error occurred');
+        expect(output.value).to.include('Another problem');
+      }
+    });
+
+    it('uses custom failure renderer when provided', () => {
+      const toModelOutput = createToModelOutput<TestInput, TestOutput>({
+        renderFailure: failure => ({
+          type: 'error-text',
+          value: `Custom failure: ${JSON.stringify(failure)}`,
+        }),
+      });
+
+      const failureResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: false,
+        problems: ['Some error'],
+      };
+
+      const output = toModelOutput(failureResult);
+      expect(output.type).to.equal('error-text');
+      if (output.type === 'error-text') {
+        expect(output.value).to.include('Custom failure');
+        expect(output.value).to.include('Some error');
+      }
+    });
+
+    it('supports multipart content with media', () => {
+      type OutputWithImage = { name: string; imageBase64: string };
+
+      const toModelOutput = createToModelOutput<TestInput, OutputWithImage>({
+        renderOutput: output => ({
+          type: 'content',
+          value: [
+            { type: 'text', text: `Image: ${output.name}` },
+            { type: 'media', data: output.imageBase64, mediaType: 'image/png' },
+          ],
+        }),
+      });
+
+      const successResult: ToolCallResult<TestInput, OutputWithImage> = {
+        ok: true,
+        name: 'screenshot.png',
+        imageBase64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('content');
+      if (output.type === 'content') {
+        expect(output.value).to.have.lengthOf(2);
+        expect(output.value[0]).to.deep.equal({ type: 'text', text: 'Image: screenshot.png' });
+        expect(output.value[1]).to.have.property('type', 'media');
+        expect(output.value[1]).to.have.property('mediaType', 'image/png');
+      }
+    });
+  });
+
+  describe('createTextToModelOutput', () => {
+    it('converts success result to formatted text', () => {
+      const toModelOutput = createTextToModelOutput<TestInput, TestOutput>();
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'data',
+        count: 10,
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        // Default uses JSON.stringify with formatting
+        expect(output.value).to.include('"result"');
+        expect(output.value).to.include('"count"');
+        expect(output.value).to.include('10');
+      }
+    });
+
+    it('uses custom formatter', () => {
+      const toModelOutput = createTextToModelOutput<TestInput, TestOutput>({
+        formatOutput: output => `Result=${output.result}, Count=${output.count}`,
+      });
+
+      const successResult: ToolCallResult<TestInput, TestOutput> = {
+        ok: true,
+        result: 'test',
+        count: 5,
+      };
+
+      const output = toModelOutput(successResult);
+      expect(output.type).to.equal('text');
+      if (output.type === 'text') {
+        expect(output.value).to.equal('Result=test, Count=5');
+      }
+    });
+  });
+
+  describe('yamlLikeFormatter', () => {
+    it('formats primitive values', () => {
+      expect(yamlLikeFormatter('hello')).to.equal('hello');
+      expect(yamlLikeFormatter(42)).to.equal('42');
+      expect(yamlLikeFormatter(true)).to.equal('true');
+      expect(yamlLikeFormatter(null)).to.equal('null');
+    });
+
+    it('formats simple objects', () => {
+      const result = yamlLikeFormatter({ name: 'test', count: 5 });
+      expect(result).to.include('name: test');
+      expect(result).to.include('count: 5');
+    });
+
+    it('formats arrays', () => {
+      const result = yamlLikeFormatter(['a', 'b', 'c']);
+      expect(result).to.include('- a');
+      expect(result).to.include('- b');
+      expect(result).to.include('- c');
+    });
+
+    it('formats nested objects', () => {
+      const result = yamlLikeFormatter({
+        user: { name: 'John', age: 30 },
+      });
+      expect(result).to.include('user:');
+      expect(result).to.include('name: John');
+      expect(result).to.include('age: 30');
+    });
+
+    it('formats empty objects and arrays', () => {
+      expect(yamlLikeFormatter({})).to.equal('{}');
+      expect(yamlLikeFormatter([])).to.equal('[]');
+    });
+
+    it('handles multi-line strings', () => {
+      const result = yamlLikeFormatter('line1\nline2\nline3');
+      expect(result).to.include('|');
+      expect(result).to.include('line1');
+      expect(result).to.include('line2');
+    });
+  });
+
+  describe('integration with tool2agent', () => {
+    it('works with tool2agent toModelOutput parameter', async () => {
+      const inputSchema = z.object({ query: z.string() });
+      const outputSchema = z.object({ result: z.string() });
+
+      const toModelOutput = createToModelOutput<
+        z.infer<typeof inputSchema>,
+        z.infer<typeof outputSchema>
+      >({
+        renderOutput: output => ({
+          type: 'text',
+          value: `Search result: ${output.result}`,
+        }),
+      });
+
+      const tool = tool2agent({
+        inputSchema,
+        outputSchema,
+        execute: async input => ({
+          ok: true as const,
+          result: `Found: ${input.query}`,
+        }),
+        toModelOutput,
+      });
+
+      // Verify toModelOutput is correctly attached to the tool
+      expect(tool.toModelOutput).to.exist;
+      expect(tool.toModelOutput).to.equal(toModelOutput);
+
+      // Execute and verify toModelOutput transforms the result
+      const result = await tool.execute({ query: 'test' }, { toolCallId: 'test', messages: [] });
+      expect(result.ok).to.be.true;
+
+      if (tool.toModelOutput) {
+        const modelOutput = tool.toModelOutput(result);
+        expect(modelOutput.type).to.equal('text');
+        if (modelOutput.type === 'text') {
+          expect(modelOutput.value).to.equal('Search result: Found: test');
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements issue #7 - adds support for custom `toModelOutput` functions to transform tool results for language models.

### Changes

This PR has been simplified based on review feedback from @klntsky:

- Add `createTextOutput(render)` - simple helper for text-based output
- Add `createJsonOutput(transform?)` - helper for JSON output with optional transformation
- Support only plain text and JSON output types (removed multipart/media support)
- Export new types and utilities from `@tool2agent/ai`
- Update README with simplified `toModelOutput` documentation
- Add comprehensive tests for the new functionality
- Deleted CLAUDE.md file

### API

The simplified API lets the user provide a function that converts the result to model output:

```typescript
import { tool2agent, createTextOutput } from '@tool2agent/ai';

const tool = tool2agent({
  inputSchema,
  outputSchema,
  execute: async (input) => ({ ok: true, result: 'success' }),
  toModelOutput: createTextOutput(result => {
    if (result.ok) {
      return \`Result: \${result.result}\`;
    }
    return \`Error: \${result.problems?.join(', ')}\`;
  }),
});
```

### Available helpers

- `createTextOutput(render)` - Creates a text output from a render function
- `createJsonOutput(transform?)` - Creates a JSON output, optionally transforming the result

## Test plan

- [x] Run `pnpm run build` - passes
- [x] Run `pnpm run lint` - passes
- [x] Run `pnpm run format:check` - passes
- [x] Run `pnpm run test` - new tests pass (pre-existing failures not related to this PR)
- [x] Verify toModelOutput is correctly attached to tools when provided
- [x] Verify createTextOutput creates text model output
- [x] Verify createJsonOutput creates JSON model output with optional transformation

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)