### PR TITLE
Replace tool2agent() catchExceptions flag with middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/tool2agent/tool2agent/issues/5
-Your prepared branch: issue-5-3325f3b0089c
-Your prepared working directory: /tmp/gh-issue-solver-1766832556098
-Your forked repository: konard/tool2agent-tool2agent
-Original repository (upstream): tool2agent/tool2agent
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/tool2agent/tool2agent/issues/5
+Your prepared branch: issue-5-3325f3b0089c
+Your prepared working directory: /tmp/gh-issue-solver-1766832556098
+Your forked repository: konard/tool2agent-tool2agent
+Original repository (upstream): tool2agent/tool2agent
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Technically speaking, tool2agent is a set of conventions that allow structuring 
 
 ### Middleware for AI SDK
 
+- [`@tool2agent/middleware-catch-exceptions`](https://github.com/tool2agent/tool2agent/tree/master/packages/middleware-catch-exceptions) - catch exceptions during tool execution and convert them to structured `ToolCallFailure` responses.
 - [`@tool2agent/middleware-idempotency`](https://github.com/tool2agent/tool2agent/tree/master/packages/middleware-idempotency) - make a tool2agent tool idempotent (refuse execution with the same parameters more than once).
 
 ## For tool2agent tooling developers

--- a/packages/ai/src/tool2agent.ts
+++ b/packages/ai/src/tool2agent.ts
@@ -1,7 +1,6 @@
 import { type ProviderOptions, ToolCallOptions, Tool, tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
-import type { ToolCallResult, ToolCallFailure } from '@tool2agent/types';
-import type { NonEmptyArray } from '@tool2agent/types';
+import type { ToolCallResult } from '@tool2agent/types';
 import { createToolCallResultSchema } from './tool-call-result-schema.js';
 
 /**
@@ -91,7 +90,6 @@ export type Tool2AgentParams<
     input: z.infer<InputSchema>,
     options: ToolCallOptions,
   ) => Promise<ToolCallResult<z.infer<InputSchema>, z.infer<OutputSchema>>>;
-  catchExceptions?: boolean;
 } & Omit<
   Tool2Agent<z.infer<InputSchema>, z.infer<OutputSchema>>,
   'inputSchema' | 'outputSchema' | 'execute'
@@ -103,7 +101,6 @@ export type Tool2AgentParams<
  * @param params.execute - function that will be called when the tool is called
  * @param params.inputSchema - the schema of the input type
  * @param params.outputSchema - the schema of the output type (can be `typeof z.never()` if none needed)
- * @param params.catchExceptions - whether to catch exceptions and return them formatted nicely to the LLM as tool2agent `problems`. defaults to true.
  * @returns a Tool2Agent type that can be used by AI SDK tools.
  * @example
  * const tool = tool2agent({
@@ -127,22 +124,6 @@ export function tool2agent<InputSchema extends z.ZodTypeAny, OutputSchema extend
   type OutputType = z.infer<OutputSchema>;
   const inputSchema = inputSchemaParam as z.ZodType<InputType>;
   const outputSchema = outputSchemaParam as z.ZodType<OutputType>;
-  const executeFunction = async (
-    input: InputType,
-    options: ToolCallOptions,
-  ): Promise<ToolCallResult<InputType, OutputType>> => {
-    // format exception into tool2agent rejection reason
-
-    if (typeof params.catchExceptions === 'undefined' || params.catchExceptions) {
-      try {
-        return await execute(input, options);
-      } catch (error: unknown) {
-        return errorToToolCallFailure<InputType>(error);
-      }
-    } else {
-      return await execute(input, options);
-    }
-  };
 
   // Convert outputSchema to ToolCallResult schema
   const toolCallResultSchema = createToolCallResultSchema<InputType, OutputType>(
@@ -154,49 +135,9 @@ export function tool2agent<InputSchema extends z.ZodTypeAny, OutputSchema extend
     ...rest,
     inputSchema,
     outputSchema: toolCallResultSchema,
-    execute: executeFunction,
+    execute,
   };
   // This is only for type checking, to ensure assignability
   const _aiTool: Tool<InputType, ToolCallResult<InputType, OutputType>> = tool(theTool);
   return theTool;
-}
-
-function errorToToolCallFailure<InputType>(error: unknown): ToolCallFailure<InputType> {
-  const errorMessage = `Exception occured during tool call execution: `;
-  if (error instanceof Error) {
-    if (error.stack) {
-      return {
-        ok: false as const,
-        problems: [errorMessage + error.stack],
-      } as ToolCallFailure<InputType>;
-    }
-    if (error.message && error.name) {
-      return {
-        ok: false,
-        problems: [errorMessage + error.name + ': ' + error.message],
-      } as ToolCallFailure<InputType>;
-    }
-    return {
-      ok: false,
-      problems: [errorMessage + error.toString()],
-    } as ToolCallFailure<InputType>;
-  }
-  // Try JSON.stringify for non-Error exceptions
-  try {
-    const jsonString = JSON.stringify(error);
-    if (jsonString !== undefined) {
-      return {
-        ok: false,
-        problems: [errorMessage + jsonString],
-      } as ToolCallFailure<InputType>;
-    }
-  } catch {
-    // Fall through to String() fallback
-  }
-  // Fall back to String() if JSON.stringify fails or returns undefined
-  const problems: NonEmptyArray<string> = [errorMessage + String(error)];
-  return {
-    ok: false,
-    problems,
-  } as ToolCallFailure<InputType>;
 }

--- a/packages/ai/test/tool2agent.test.ts
+++ b/packages/ai/test/tool2agent.test.ts
@@ -9,226 +9,66 @@ const outputSchema = z.object({ result: z.string() });
 type InputType = z.infer<typeof inputSchema>;
 type OutputType = z.infer<typeof outputSchema>;
 
-describe('tool2agent error handling', () => {
-  describe('catchExceptions = true (default)', () => {
-    it('handles Error with stack trace', async () => {
-      const error = new Error('Test error');
-      error.stack = 'Error: Test error\n    at test.js:1:1';
+describe('tool2agent', () => {
+  describe('basic functionality', () => {
+    it('creates a tool that executes successfully', async () => {
+      const tool: Tool2Agent<InputType, OutputType> = tool2agent({
+        inputSchema,
+        outputSchema,
+        execute: async params => {
+          return { ok: true, result: `Processed: ${params.value}` };
+        },
+      });
 
+      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
+
+      expect(result.ok).to.be.true;
+      if (result.ok) {
+        expect(result.result).to.equal('Processed: test');
+      }
+    });
+
+    it('preserves tool description', async () => {
+      const tool: Tool2Agent<InputType, OutputType> = tool2agent({
+        description: 'A test tool',
+        inputSchema,
+        outputSchema,
+        execute: async () => {
+          return { ok: true, result: 'test' };
+        },
+      });
+
+      expect(tool.description).to.equal('A test tool');
+    });
+
+    it('has input and output schemas', async () => {
       const tool: Tool2Agent<InputType, OutputType> = tool2agent({
         inputSchema,
         outputSchema,
         execute: async () => {
-          throw error;
+          return { ok: true, result: 'test' };
         },
       });
 
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal([
-          'Exception occured during tool call execution: Error: Test error\n    at test.js:1:1',
-        ]);
-      }
-    });
-
-    it('handles Error with name and message (no stack)', async () => {
-      const error = new Error('Test error');
-      error.stack = undefined;
-      error.name = 'CustomError';
-
-      const tool: Tool2Agent<InputType, OutputType> = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw error;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal([
-          'Exception occured during tool call execution: CustomError: Test error',
-        ]);
-      }
-    });
-
-    it('handles Error with toString() fallback', async () => {
-      const error = new Error('Test error');
-      error.stack = undefined;
-      // Remove name and message to force toString() fallback
-      delete (error as unknown as { name?: string }).name;
-      delete (error as unknown as { message?: string }).message;
-
-      const tool: Tool2Agent<InputType, OutputType> = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw error;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok && result.problems) {
-        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
-        expect(result.problems[0]).to.include('Error');
-      }
-    });
-
-    it('handles non-Error exceptions (string)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw 'String error';
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal([
-          'Exception occured during tool call execution: "String error"',
-        ]);
-      }
-    });
-
-    it('handles non-Error exceptions (number)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw 42;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal(['Exception occured during tool call execution: 42']);
-      }
-    });
-
-    it('handles non-Error exceptions (null)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw null;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal([
-          'Exception occured during tool call execution: null',
-        ]);
-      }
-    });
-
-    it('handles non-Error exceptions (undefined)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw undefined;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok) {
-        expect(result.problems).to.deep.equal([
-          'Exception occured during tool call execution: undefined',
-        ]);
-      }
-    });
-
-    it('handles non-Error exceptions (object)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw { code: 500, message: 'Internal error' };
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok && result.problems) {
-        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
-        expect(result.problems[0]).to.include('{"code":500,"message":"Internal error"}');
-      }
-    });
-
-    it('handles non-Error exceptions (function - JSON.stringify returns undefined)', async () => {
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw () => {};
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok && result.problems) {
-        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
-        // Should fall back to String() when JSON.stringify returns undefined
-        expect(result.problems[0]).to.include('() => {}');
-      }
-    });
-
-    it('handles non-Error exceptions (object with circular reference - JSON.stringify throws)', async () => {
-      const circular: any = { code: 500, message: 'Internal error' };
-      circular.self = circular; // Create circular reference
-
-      const tool = tool2agent({
-        inputSchema,
-        outputSchema,
-        execute: async () => {
-          throw circular;
-        },
-      });
-
-      const result = await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
-
-      expect(result.ok).to.be.false;
-      if (!result.ok && result.problems) {
-        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
-        // Should fall back to String() for circular references
-        expect(result.problems[0]).to.include('[object Object]');
-      }
+      expect(tool.inputSchema).to.exist;
+      expect(tool.outputSchema).to.exist;
     });
   });
 
-  describe('catchExceptions = false', () => {
-    it('propagates exceptions when catchExceptions is false', async () => {
+  describe('exception propagation', () => {
+    it('propagates exceptions (use catchExceptions middleware to catch them)', async () => {
       const error = new Error('Test error');
 
       const tool = tool2agent({
         inputSchema,
         outputSchema,
-        catchExceptions: false,
         execute: async () => {
           throw error;
         },
       });
 
       try {
-        await tool.execute!({ value: 'test' }, { toolCallId: 'test', messages: [] });
+        await tool.execute({ value: 'test' }, { toolCallId: 'test', messages: [] });
         expect.fail('Expected exception to be thrown');
       } catch (thrownError) {
         expect(thrownError).to.equal(error);

--- a/packages/middleware-catch-exceptions/.mocharc.unit.json
+++ b/packages/middleware-catch-exceptions/.mocharc.unit.json
@@ -1,0 +1,7 @@
+{
+  "spec": "test/**/*.unit.test.ts",
+  "loader": "ts-node/esm",
+  "extensions": ["ts"],
+  "recursive": true,
+  "require": ["mocha-suppress-logs"]
+}

--- a/packages/middleware-catch-exceptions/CHANGELOG.md
+++ b/packages/middleware-catch-exceptions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+Initial release

--- a/packages/middleware-catch-exceptions/LICENSE
+++ b/packages/middleware-catch-exceptions/LICENSE
@@ -1,0 +1,28 @@
+The Unlicense
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>
+
+

--- a/packages/middleware-catch-exceptions/README.md
+++ b/packages/middleware-catch-exceptions/README.md
@@ -1,0 +1,72 @@
+# @tool2agent/middleware-catch-exceptions [![API docs](https://img.shields.io/badge/API%20docs-blue)](https://tool2agent.org/docs/)
+
+Exception catching middleware for tool2agent. Catches exceptions during tool execution and converts them to structured `ToolCallFailure` responses with formatted error messages.
+
+## Installation
+
+```bash
+pnpm add @tool2agent/middleware-catch-exceptions
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { catchExceptions } from '@tool2agent/middleware-catch-exceptions';
+import { tool2agent } from '@tool2agent/ai';
+import { z } from 'zod';
+
+const tool = tool2agent({
+  inputSchema,
+  outputSchema,
+  execute: async (input) => {
+    // This might throw an exception
+    const result = await riskyOperation(input);
+    return { ok: true, result };
+  },
+});
+
+// Apply the middleware to catch and format exceptions
+const safeTool = catchExceptions<InputType, OutputType>().applyTo(tool);
+
+// Exceptions are now caught and returned as structured failures
+const result = await safeTool.execute({ query: 'test' }, ...);
+// If an exception occurs:
+// result = { ok: false, problems: ['Exception occured during tool call execution: Error: ...'] }
+```
+
+### With custom options
+
+```typescript
+const safeTool = catchExceptions<InputType, OutputType>({
+  formatProblems: (error, input) => [
+    `Failed to process ${input.query}: ${error instanceof Error ? error.message : String(error)}`
+  ],
+  formatInstructions: () => ['Please check your input and try again.'],
+  onException: (error, input) => console.error('Tool execution failed:', error),
+}).applyTo(tool);
+```
+
+### Error formatting
+
+The default formatter handles various error types:
+
+- `Error` objects with stack traces
+- `Error` objects with name and message (no stack)
+- Non-Error exceptions (strings, numbers, objects)
+- Objects with circular references (falls back to `String()`)
+
+### Middleware composition
+
+This middleware can be composed with other middlewares using `.pipe()`:
+
+```typescript
+import { catchExceptions } from '@tool2agent/middleware-catch-exceptions';
+import { idempotency } from '@tool2agent/middleware-idempotency';
+
+const middleware = catchExceptions<InputType, OutputType>()
+  .pipe(idempotency<InputType, OutputType>());
+
+const safeTool = middleware.applyTo(baseTool);
+```

--- a/packages/middleware-catch-exceptions/README.md
+++ b/packages/middleware-catch-exceptions/README.md
@@ -41,7 +41,7 @@ const result = await safeTool.execute({ query: 'test' }, ...);
 ```typescript
 const safeTool = catchExceptions<InputType, OutputType>({
   formatProblems: (error, input) => [
-    `Failed to process ${input.query}: ${error instanceof Error ? error.message : String(error)}`
+    `Failed to process ${input.query}: ${error instanceof Error ? error.message : String(error)}`,
   ],
   formatInstructions: () => ['Please check your input and try again.'],
   onException: (error, input) => console.error('Tool execution failed:', error),
@@ -65,8 +65,9 @@ This middleware can be composed with other middlewares using `.pipe()`:
 import { catchExceptions } from '@tool2agent/middleware-catch-exceptions';
 import { idempotency } from '@tool2agent/middleware-idempotency';
 
-const middleware = catchExceptions<InputType, OutputType>()
-  .pipe(idempotency<InputType, OutputType>());
+const middleware = catchExceptions<InputType, OutputType>().pipe(
+  idempotency<InputType, OutputType>(),
+);
 
 const safeTool = middleware.applyTo(baseTool);
 ```

--- a/packages/middleware-catch-exceptions/eslint.config.js
+++ b/packages/middleware-catch-exceptions/eslint.config.js
@@ -1,0 +1,27 @@
+import { baseConfig } from '../../eslint.config.base.js';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+];

--- a/packages/middleware-catch-exceptions/package.json
+++ b/packages/middleware-catch-exceptions/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@tool2agent/middleware-catch-exceptions",
+  "version": "0.0.1",
+  "description": "Exception catching middleware for tool2agent",
+  "type": "module",
+  "main": "dist-cjs/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "dist-cjs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc && tsc -p tsconfig.cjs.json",
+    "build:all": "tsc -p tsconfig-all.json",
+    "build:watch": "tsc --watch",
+    "clean": "rm -rf dist dist-cjs",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "pnpm test:unit",
+    "test:unit": "mocha --config .mocharc.unit.json",
+    "test:watch": "mocha --config .mocharc.unit.json --watch",
+    "prepack": "pnpm run build"
+  },
+  "keywords": [
+    "tool2agent",
+    "middleware"
+  ],
+  "author": "klntsky",
+  "license": "Unlicense",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tool2agent/tool2agent.git"
+  },
+  "homepage": "https://github.com/tool2agent/tool2agent#readme",
+  "bugs": {
+    "url": "https://github.com/tool2agent/tool2agent/issues"
+  },
+  "readme": "README.md",
+  "dependencies": {
+    "@tool2agent/ai": "workspace:*",
+    "@tool2agent/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider-utils": "^3.0.13",
+    "@types/chai": "^5.2.2",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^24.9.2",
+    "chai": "^5.2.0",
+    "mocha": "^11.5.0",
+    "mocha-suppress-logs": "^0.6.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3",
+    "zod": "^4.1.12"
+  },
+  "peerDependencies": {
+    "zod": "^4"
+  }
+}

--- a/packages/middleware-catch-exceptions/src/index.ts
+++ b/packages/middleware-catch-exceptions/src/index.ts
@@ -1,0 +1,168 @@
+import { createMiddleware, type Middleware, type Tool2Agent } from '@tool2agent/ai';
+import type { ToolCallResult, ToolCallFailure, NonEmptyArray } from '@tool2agent/types';
+import type { ToolCallOptions } from '@ai-sdk/provider-utils';
+
+/**
+ * Options for configuring the exception catching middleware.
+ *
+ * @template InputType - The input type of the tool
+ */
+export interface CatchExceptionsOptions<InputType> {
+  /**
+   * Custom formatter for the problem messages when an exception is caught.
+   * @param error - The caught exception
+   * @param input - The input that caused the exception
+   * @returns The problem messages
+   */
+  formatProblems?: (error: unknown, input: InputType) => NonEmptyArray<string>;
+  /**
+   * Custom formatter for the instruction messages when an exception is caught.
+   * @param error - The caught exception
+   * @param input - The input that caused the exception
+   * @returns The instruction messages, or undefined if no instructions should be added
+   */
+  formatInstructions?: (error: unknown, input: InputType) => NonEmptyArray<string> | undefined;
+  /**
+   * Optional callback for when an exception is caught.
+   * Exceptions thrown by this callback are ignored.
+   * @param error - The caught exception
+   * @param input - The input that caused the exception
+   */
+  onException?: (error: unknown, input: InputType) => void | Promise<void>;
+}
+
+/**
+ * Default formatter for exception problem messages.
+ * Handles Error objects with stack traces, name/message, and toString() fallback.
+ * Also handles non-Error exceptions using JSON.stringify with String() fallback.
+ *
+ * @param error - The caught exception
+ * @returns The formatted problem message
+ */
+function defaultFormatProblems(error: unknown): NonEmptyArray<string> {
+  const errorMessage = `Exception occured during tool call execution: `;
+  if (error instanceof Error) {
+    if (error.stack) {
+      return [errorMessage + error.stack];
+    }
+    if (error.message && error.name) {
+      return [errorMessage + error.name + ': ' + error.message];
+    }
+    return [errorMessage + error.toString()];
+  }
+  // Try JSON.stringify for non-Error exceptions
+  try {
+    const jsonString = JSON.stringify(error);
+    if (jsonString !== undefined) {
+      return [errorMessage + jsonString];
+    }
+  } catch {
+    // Fall through to String() fallback
+  }
+  // Fall back to String() if JSON.stringify fails or returns undefined
+  return [errorMessage + String(error)];
+}
+
+/**
+ * Converts an error to a ToolCallFailure response.
+ *
+ * @template InputType - The input type of the tool
+ * @param error - The caught exception
+ * @param input - The input that caused the exception
+ * @param options - The middleware options
+ * @returns A ToolCallFailure response
+ */
+function errorToToolCallFailure<InputType>(
+  error: unknown,
+  input: InputType,
+  options: CatchExceptionsOptions<InputType>,
+): ToolCallFailure<InputType> {
+  const { formatProblems = defaultFormatProblems, formatInstructions } = options;
+  const problems = formatProblems(error, input);
+  const instructions = formatInstructions?.(error, input);
+
+  if (instructions) {
+    return {
+      ok: false,
+      problems,
+      instructions,
+    } as ToolCallFailure<InputType>;
+  }
+
+  return {
+    ok: false,
+    problems,
+  } as ToolCallFailure<InputType>;
+}
+
+/**
+ * Creates a middleware that catches exceptions during tool execution and converts them
+ * to structured ToolCallFailure responses with formatted error messages.
+ *
+ * This middleware replaces the `catchExceptions` flag in `tool2agent()` and provides
+ * more flexibility through customizable formatters and callbacks.
+ *
+ * @param options - Optional configuration for the exception catching middleware
+ * @returns A middleware that can be applied to a Tool2Agent
+ *
+ * @example
+ * ```ts
+ * import { catchExceptions } from '@tool2agent/middleware-catch-exceptions';
+ * import { tool2agent } from '@tool2agent/ai';
+ *
+ * const tool = tool2agent({
+ *   inputSchema,
+ *   outputSchema,
+ *   execute: async (input) => {
+ *     // This might throw an exception
+ *     const result = await riskyOperation(input);
+ *     return { ok: true, result };
+ *   },
+ * });
+ *
+ * // Apply the middleware to catch and format exceptions
+ * const safeTool = catchExceptions().applyTo(tool);
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With custom options
+ * const safeTool = catchExceptions({
+ *   formatProblems: (error, input) => [`Failed to process ${input.name}: ${error}`],
+ *   formatInstructions: () => ['Please check your input and try again.'],
+ *   onException: (error, input) => console.error('Tool execution failed:', error),
+ * }).applyTo(tool);
+ * ```
+ */
+export function catchExceptions<InputType, OutputType>(
+  options?: CatchExceptionsOptions<InputType>,
+): Middleware<InputType, OutputType> {
+  const resolvedOptions = options ?? {};
+
+  return createMiddleware<InputType, OutputType>({
+    transform: (tool: Tool2Agent<InputType, OutputType>): Tool2Agent<InputType, OutputType> => {
+      const { execute } = tool;
+
+      return {
+        ...tool,
+        execute: async (
+          input: InputType,
+          toolCallOptions: ToolCallOptions,
+        ): Promise<ToolCallResult<InputType, OutputType>> => {
+          try {
+            return await execute(input, toolCallOptions);
+          } catch (error: unknown) {
+            if (resolvedOptions.onException) {
+              try {
+                await resolvedOptions.onException(error, input);
+              } catch {
+                // Ignore exceptions from the callback
+              }
+            }
+            return errorToToolCallFailure<InputType>(error, input, resolvedOptions);
+          }
+        },
+      };
+    },
+  });
+}

--- a/packages/middleware-catch-exceptions/test/catch-exceptions.unit.test.ts
+++ b/packages/middleware-catch-exceptions/test/catch-exceptions.unit.test.ts
@@ -1,0 +1,364 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { tool2agent } from '@tool2agent/ai';
+import { catchExceptions } from '../src/index.js';
+import type { ToolCallOptions } from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+import type { ToolCallResult } from '@tool2agent/types';
+
+const inputSchema = z.object({ value: z.string() });
+const outputSchema = z.object({ result: z.string() });
+
+type InputType = z.infer<typeof inputSchema>;
+type OutputType = z.infer<typeof outputSchema>;
+
+describe('catchExceptions middleware', () => {
+  const toolCallOptions: ToolCallOptions = {
+    toolCallId: 'test-id',
+    messages: [],
+  };
+
+  const createThrowingTool = (error: unknown) =>
+    tool2agent({
+      inputSchema,
+      outputSchema,
+      execute: async (): Promise<ToolCallResult<InputType, OutputType>> => {
+        throw error;
+      },
+    });
+
+  const createSuccessfulTool = () =>
+    tool2agent({
+      inputSchema,
+      outputSchema,
+      execute: async (params: InputType): Promise<ToolCallResult<InputType, OutputType>> => {
+        return { ok: true, result: `Processed: ${params.value}` };
+      },
+    });
+
+  describe('basic functionality', () => {
+    it('allows successful calls to proceed', async () => {
+      const baseTool = createSuccessfulTool();
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.true;
+      if (result.ok) {
+        expect(result.result).to.equal('Processed: test');
+      }
+    });
+
+    it('catches exceptions and returns ToolCallFailure', async () => {
+      const error = new Error('Test error');
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.be.an('array').with.length.greaterThan(0);
+        expect(result.problems![0]).to.include('Exception occured during tool call execution: ');
+      }
+    });
+  });
+
+  describe('error formatting', () => {
+    it('handles Error with stack trace', async () => {
+      const error = new Error('Test error');
+      error.stack = 'Error: Test error\n    at test.js:1:1';
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal([
+          'Exception occured during tool call execution: Error: Test error\n    at test.js:1:1',
+        ]);
+      }
+    });
+
+    it('handles Error with name and message (no stack)', async () => {
+      const error = new Error('Test error');
+      error.stack = undefined;
+      error.name = 'CustomError';
+
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal([
+          'Exception occured during tool call execution: CustomError: Test error',
+        ]);
+      }
+    });
+
+    it('handles Error with toString() fallback', async () => {
+      const error = new Error('Test error');
+      error.stack = undefined;
+      // Remove name and message to force toString() fallback
+      delete (error as unknown as { name?: string }).name;
+      delete (error as unknown as { message?: string }).message;
+
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok && result.problems) {
+        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
+        expect(result.problems[0]).to.include('Error');
+      }
+    });
+
+    it('handles non-Error exceptions (string)', async () => {
+      const baseTool = createThrowingTool('String error');
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal([
+          'Exception occured during tool call execution: "String error"',
+        ]);
+      }
+    });
+
+    it('handles non-Error exceptions (number)', async () => {
+      const baseTool = createThrowingTool(42);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal(['Exception occured during tool call execution: 42']);
+      }
+    });
+
+    it('handles non-Error exceptions (null)', async () => {
+      const baseTool = createThrowingTool(null);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal([
+          'Exception occured during tool call execution: null',
+        ]);
+      }
+    });
+
+    it('handles non-Error exceptions (undefined)', async () => {
+      const baseTool = createThrowingTool(undefined);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal([
+          'Exception occured during tool call execution: undefined',
+        ]);
+      }
+    });
+
+    it('handles non-Error exceptions (object)', async () => {
+      const baseTool = createThrowingTool({ code: 500, message: 'Internal error' });
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok && result.problems) {
+        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
+        expect(result.problems[0]).to.include('{"code":500,"message":"Internal error"}');
+      }
+    });
+
+    it('handles non-Error exceptions (function - JSON.stringify returns undefined)', async () => {
+      const baseTool = createThrowingTool(() => {});
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok && result.problems) {
+        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
+        // Should fall back to String() when JSON.stringify returns undefined
+        // Note: arrow function stringification may have spaces, so we check for the core pattern
+        expect(result.problems[0]).to.match(/\(\) => \{\s*\}/);
+      }
+    });
+
+    it('handles non-Error exceptions (object with circular reference - JSON.stringify throws)', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const circular: any = { code: 500, message: 'Internal error' };
+      circular.self = circular; // Create circular reference
+
+      const baseTool = createThrowingTool(circular);
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok && result.problems) {
+        expect(result.problems[0]).to.include('Exception occured during tool call execution: ');
+        // Should fall back to String() for circular references
+        expect(result.problems[0]).to.include('[object Object]');
+      }
+    });
+  });
+
+  describe('custom formatters', () => {
+    it('uses custom formatProblems', async () => {
+      const error = new Error('Custom error');
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>({
+        formatProblems: (err, input) => [
+          `Failed for ${input.value}: ${err instanceof Error ? err.message : String(err)}`,
+        ],
+      }).applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.problems).to.deep.equal(['Failed for test: Custom error']);
+      }
+    });
+
+    it('uses custom formatInstructions', async () => {
+      const error = new Error('Test error');
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>({
+        formatInstructions: () => ['Please try again with different input.'],
+      }).applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.instructions).to.deep.equal(['Please try again with different input.']);
+      }
+    });
+
+    it('does not include instructions when formatInstructions returns undefined', async () => {
+      const error = new Error('Test error');
+      const baseTool = createThrowingTool(error);
+      const safeTool = catchExceptions<InputType, OutputType>({
+        formatInstructions: () => undefined,
+      }).applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      if (!result.ok) {
+        expect(result.instructions).to.be.undefined;
+      }
+    });
+  });
+
+  describe('onException callback', () => {
+    it('calls onException when exception is caught', async () => {
+      const error = new Error('Test error');
+      const baseTool = createThrowingTool(error);
+      let exceptionCalled = false;
+      let caughtError: unknown;
+      let caughtInput: InputType | undefined;
+
+      const safeTool = catchExceptions<InputType, OutputType>({
+        onException: (err, input) => {
+          exceptionCalled = true;
+          caughtError = err;
+          caughtInput = input;
+        },
+      }).applyTo(baseTool);
+
+      await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(exceptionCalled).to.be.true;
+      expect(caughtError).to.equal(error);
+      expect(caughtInput).to.deep.equal({ value: 'test' });
+    });
+
+    it('does not call onException for successful calls', async () => {
+      const baseTool = createSuccessfulTool();
+      let exceptionCalled = false;
+
+      const safeTool = catchExceptions<InputType, OutputType>({
+        onException: () => {
+          exceptionCalled = true;
+        },
+      }).applyTo(baseTool);
+
+      await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(exceptionCalled).to.be.false;
+    });
+
+    it('ignores exceptions thrown by onException callback', async () => {
+      const error = new Error('Original error');
+      const baseTool = createThrowingTool(error);
+
+      const safeTool = catchExceptions<InputType, OutputType>({
+        onException: () => {
+          throw new Error('Callback error');
+        },
+      }).applyTo(baseTool);
+
+      const result = await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      // Should still return the original error, not the callback error
+      expect(result.ok).to.be.false;
+      if (!result.ok && result.problems) {
+        expect(result.problems[0]).to.include('Original error');
+      }
+    });
+
+    it('handles async onException callback', async () => {
+      const error = new Error('Test error');
+      const baseTool = createThrowingTool(error);
+      let exceptionCalled = false;
+
+      const safeTool = catchExceptions<InputType, OutputType>({
+        onException: async () => {
+          await new Promise(resolve => setTimeout(resolve, 10));
+          exceptionCalled = true;
+        },
+      }).applyTo(baseTool);
+
+      await safeTool.execute({ value: 'test' }, toolCallOptions);
+
+      expect(exceptionCalled).to.be.true;
+    });
+  });
+
+  describe('middleware composition', () => {
+    it('preserves other tool properties', async () => {
+      const baseTool = tool2agent({
+        description: 'A test tool',
+        inputSchema,
+        outputSchema,
+        execute: async (): Promise<ToolCallResult<InputType, OutputType>> => {
+          throw new Error('Test error');
+        },
+      });
+
+      const safeTool = catchExceptions<InputType, OutputType>().applyTo(baseTool);
+
+      expect(safeTool.description).to.equal('A test tool');
+      expect(safeTool.inputSchema).to.equal(baseTool.inputSchema);
+      expect(safeTool.outputSchema).to.equal(baseTool.outputSchema);
+    });
+  });
+});

--- a/packages/middleware-catch-exceptions/tsconfig-all.json
+++ b/packages/middleware-catch-exceptions/tsconfig-all.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/middleware-catch-exceptions/tsconfig.cjs.json
+++ b/packages/middleware-catch-exceptions/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist-cjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/middleware-catch-exceptions/tsconfig.json
+++ b/packages/middleware-catch-exceptions/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node", "mocha", "chai"],
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,46 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
 
+  packages/middleware-catch-exceptions:
+    dependencies:
+      '@tool2agent/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@tool2agent/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@ai-sdk/provider-utils':
+        specifier: ^3.0.13
+        version: 3.0.14(zod@4.1.12)
+      '@types/chai':
+        specifier: ^5.2.2
+        version: 5.2.3
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: ^24.9.2
+        version: 24.9.2
+      chai:
+        specifier: ^5.2.0
+        version: 5.3.3
+      mocha:
+        specifier: ^11.5.0
+        version: 11.7.4
+      mocha-suppress-logs:
+        specifier: ^0.6.0
+        version: 0.6.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.9.2)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+
   packages/middleware-idempotency:
     dependencies:
       '@tool2agent/ai':


### PR DESCRIPTION
## Summary

This PR replaces the `catchExceptions` flag in `tool2agent()` with a new `@tool2agent/middleware-catch-exceptions` package, as requested in #5.

**Breaking Change:** Exceptions now propagate by default instead of being caught.

- Created new `@tool2agent/middleware-catch-exceptions` package following the existing middleware pattern
- Removed `catchExceptions` flag from `tool2agent()` 
- Added comprehensive tests for the new middleware
- Updated documentation

## Migration Guide

Before:
```typescript
const tool = tool2agent({
  inputSchema,
  outputSchema,
  execute: async (input) => { ... },
  // catchExceptions was true by default
});
```

After:
```typescript
import { catchExceptions } from '@tool2agent/middleware-catch-exceptions';

const tool = tool2agent({
  inputSchema,
  outputSchema,
  execute: async (input) => { ... },
});

// Apply middleware to catch exceptions
const safeTool = catchExceptions().applyTo(tool);
```

## New Features

The new middleware provides more flexibility than the previous flag:
- Custom `formatProblems` function to customize error messages
- Custom `formatInstructions` function to add instructions to error responses  
- `onException` callback for logging or other side effects

## Test plan

- [x] All existing unit tests pass
- [x] New middleware has 20 unit tests covering:
  - Basic exception catching functionality
  - Various error types (Error, string, number, null, undefined, object, function, circular references)
  - Custom formatters (formatProblems, formatInstructions)
  - onException callback
  - Middleware composition

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)