### PR TITLE
Add @tool2agent/middleware-logging package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/tool2agent/tool2agent/issues/2
-Your prepared branch: issue-2-ff3e9b6b4ac2
-Your prepared working directory: /tmp/gh-issue-solver-1766832608013
-Your forked repository: konard/tool2agent-tool2agent
-Original repository (upstream): tool2agent/tool2agent
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/tool2agent/tool2agent/issues/2
+Your prepared branch: issue-2-ff3e9b6b4ac2
+Your prepared working directory: /tmp/gh-issue-solver-1766832608013
+Your forked repository: konard/tool2agent-tool2agent
+Original repository (upstream): tool2agent/tool2agent
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Technically speaking, tool2agent is a set of conventions that allow structuring 
 ### Middleware for AI SDK
 
 - [`@tool2agent/middleware-idempotency`](https://github.com/tool2agent/tool2agent/tree/master/packages/middleware-idempotency) - make a tool2agent tool idempotent (refuse execution with the same parameters more than once).
+- [`@tool2agent/middleware-logging`](https://github.com/tool2agent/tool2agent/tree/master/packages/middleware-logging) - log tool call inputs, outputs, and timing information with a configurable logger function.
 
 ## For tool2agent tooling developers
 

--- a/packages/middleware-logging/.mocharc.unit.json
+++ b/packages/middleware-logging/.mocharc.unit.json
@@ -1,0 +1,7 @@
+{
+  "spec": "test/**/*.unit.test.ts",
+  "loader": "ts-node/esm",
+  "extensions": ["ts"],
+  "recursive": true,
+  "require": ["mocha-suppress-logs"]
+}

--- a/packages/middleware-logging/README.md
+++ b/packages/middleware-logging/README.md
@@ -1,0 +1,143 @@
+# @tool2agent/middleware-logging [![API docs](https://img.shields.io/badge/API%20docs-blue)](https://tool2agent.org/docs/)
+
+Logging middleware for tool2agent. Logs tool call inputs, outputs, and timing information.
+
+## Installation
+
+```bash
+pnpm add @tool2agent/middleware-logging
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { logging } from '@tool2agent/middleware-logging';
+import { tool2agent } from '@tool2agent/ai';
+import { z } from 'zod';
+
+const tool = tool2agent({
+  inputSchema,
+  outputSchema,
+  execute: async input => {
+    return { ok: true, result: `Processed: ${input.query}` };
+  },
+});
+
+const loggedTool = logging<InputType, OutputType>({
+  logger: entry => console.log('Tool call:', entry),
+}).applyTo(tool);
+
+// Execute the tool - logging happens automatically
+const result = await loggedTool.execute({ query: 'test' }, options);
+// Console output:
+// Tool call: {
+//   input: { query: 'test' },
+//   result: { ok: true, result: 'Processed: test' },
+//   options: { toolCallId: '...', messages: [...] },
+//   durationMs: 5.123,
+//   startedAt: 2024-01-01T00:00:00.000Z,
+//   completedAt: 2024-01-01T00:00:00.005Z
+// }
+```
+
+### Log Entry Structure
+
+The logger function receives a `LogEntry` object with the following properties:
+
+```typescript
+interface LogEntry<InputType, OutputType> {
+  input: InputType; // The input passed to the tool
+  result: ToolCallResult<InputType, OutputType>; // The result from the tool
+  options: ToolCallOptions; // Tool call options (includes toolCallId)
+  durationMs: number; // Execution duration in milliseconds
+  startedAt: Date; // When the tool call started
+  completedAt: Date; // When the tool call completed
+}
+```
+
+### Async Logger
+
+The logger function can be async, useful for sending logs to external services:
+
+```typescript
+const loggedTool = logging<InputType, OutputType>({
+  logger: async entry => {
+    await saveToDatabase({
+      toolCallId: entry.options.toolCallId,
+      input: entry.input,
+      success: entry.result.ok,
+      durationMs: entry.durationMs,
+      timestamp: entry.startedAt,
+    });
+  },
+}).applyTo(tool);
+```
+
+### Composing with Other Middleware
+
+```typescript
+import { logging } from '@tool2agent/middleware-logging';
+import { idempotency } from '@tool2agent/middleware-idempotency';
+
+const tool = logging<InputType, OutputType>({
+  logger: entry => console.log(entry),
+})
+  .pipe(idempotency<InputType, OutputType>())
+  .applyTo(baseTool);
+```
+
+### Custom Logger Examples
+
+#### File logging
+
+```typescript
+import * as fs from 'fs';
+
+const loggedTool = logging<InputType, OutputType>({
+  logger: entry => {
+    const logLine =
+      JSON.stringify({
+        timestamp: entry.startedAt.toISOString(),
+        toolCallId: entry.options.toolCallId,
+        success: entry.result.ok,
+        durationMs: entry.durationMs,
+      }) + '\n';
+    fs.appendFileSync('tool-calls.log', logLine);
+  },
+}).applyTo(tool);
+```
+
+#### Structured logging with Winston/Pino
+
+```typescript
+import pino from 'pino';
+
+const pinoLogger = pino();
+
+const loggedTool = logging<InputType, OutputType>({
+  logger: entry => {
+    pinoLogger.info({
+      event: 'tool_call',
+      toolCallId: entry.options.toolCallId,
+      success: entry.result.ok,
+      durationMs: entry.durationMs,
+      input: entry.input,
+    });
+  },
+}).applyTo(tool);
+```
+
+#### Metrics collection
+
+```typescript
+const loggedTool = logging<InputType, OutputType>({
+  logger: entry => {
+    metrics.histogram('tool_call_duration', entry.durationMs);
+    metrics.increment('tool_calls_total', {
+      success: String(entry.result.ok),
+    });
+  },
+}).applyTo(tool);
+```

--- a/packages/middleware-logging/eslint.config.js
+++ b/packages/middleware-logging/eslint.config.js
@@ -1,0 +1,27 @@
+import { baseConfig } from '../../eslint.config.base.js';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
+  },
+];

--- a/packages/middleware-logging/package.json
+++ b/packages/middleware-logging/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@tool2agent/middleware-logging",
+  "version": "0.0.1",
+  "description": "Logging middleware for tool2agent",
+  "type": "module",
+  "main": "dist-cjs/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist-cjs/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "dist-cjs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc && tsc -p tsconfig.cjs.json",
+    "build:all": "tsc -p tsconfig-all.json",
+    "build:watch": "tsc --watch",
+    "clean": "rm -rf dist dist-cjs",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "pnpm test:unit",
+    "test:unit": "mocha --config .mocharc.unit.json",
+    "test:watch": "mocha --config .mocharc.unit.json --watch",
+    "prepack": "pnpm run build"
+  },
+  "keywords": [
+    "tool2agent",
+    "middleware",
+    "logging"
+  ],
+  "author": "klntsky",
+  "license": "Unlicense",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tool2agent/tool2agent.git"
+  },
+  "homepage": "https://github.com/tool2agent/tool2agent#readme",
+  "bugs": {
+    "url": "https://github.com/tool2agent/tool2agent/issues"
+  },
+  "readme": "README.md",
+  "dependencies": {
+    "@tool2agent/ai": "workspace:*",
+    "@tool2agent/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider-utils": "^3.0.13",
+    "@types/chai": "^5.2.2",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^24.9.2",
+    "chai": "^5.2.0",
+    "mocha": "^11.5.0",
+    "mocha-suppress-logs": "^0.6.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3",
+    "zod": "^4.1.12"
+  },
+  "peerDependencies": {
+    "zod": "^4"
+  }
+}

--- a/packages/middleware-logging/src/index.ts
+++ b/packages/middleware-logging/src/index.ts
@@ -1,0 +1,158 @@
+import { createMiddleware, type Middleware, type Tool2Agent } from '@tool2agent/ai';
+import type { ToolCallResult } from '@tool2agent/types';
+import type { ToolCallOptions } from '@ai-sdk/provider-utils';
+
+/**
+ * Log entry for a tool call, containing input, output, and timing information.
+ *
+ * @template InputType - The input type of the tool
+ * @template OutputType - The output type of the tool
+ */
+export interface LogEntry<InputType, OutputType> {
+  /**
+   * The input that was passed to the tool.
+   */
+  input: InputType;
+  /**
+   * The result returned by the tool execution.
+   */
+  result: ToolCallResult<InputType, OutputType>;
+  /**
+   * The tool call options passed to the execute function.
+   */
+  options: ToolCallOptions;
+  /**
+   * The duration of the tool call execution in milliseconds.
+   */
+  durationMs: number;
+  /**
+   * The timestamp when the tool call started.
+   */
+  startedAt: Date;
+  /**
+   * The timestamp when the tool call completed.
+   */
+  completedAt: Date;
+}
+
+/**
+ * Logger function type that receives log entries for tool calls.
+ *
+ * @template InputType - The input type of the tool
+ * @template OutputType - The output type of the tool
+ */
+export type Logger<InputType, OutputType> = (
+  entry: LogEntry<InputType, OutputType>,
+) => void | Promise<void>;
+
+/**
+ * Options for configuring the logging middleware.
+ *
+ * @template InputType - The input type of the tool
+ * @template OutputType - The output type of the tool
+ */
+export interface LoggingOptions<InputType, OutputType> {
+  /**
+   * The logger function that will be called with log entries for each tool call.
+   * This is a required option - you must provide a logger function.
+   *
+   * @example
+   * ```ts
+   * logger: (entry) => console.log(`Tool call completed in ${entry.durationMs}ms`, entry)
+   * ```
+   */
+  logger: Logger<InputType, OutputType>;
+}
+
+/**
+ * Creates a middleware that logs tool call inputs, outputs, and timing information.
+ *
+ * @param options - Configuration for the logging middleware
+ * @returns A middleware that can be applied to a Tool2Agent
+ *
+ * @example
+ * ```ts
+ * import { logging } from '@tool2agent/middleware-logging';
+ * import { tool2agent } from '@tool2agent/ai';
+ *
+ * const tool = tool2agent<InputType, OutputType>({
+ *   inputSchema,
+ *   outputSchema,
+ *   execute: async (input) => ({ ok: true, result: `Processed: ${input.query}` }),
+ * });
+ *
+ * // With console logging
+ * const loggedTool = logging<InputType, OutputType>({
+ *   logger: (entry) => console.log('Tool call:', entry),
+ * }).applyTo(tool);
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With custom logging (e.g., to a file or external service)
+ * const loggedTool = logging<InputType, OutputType>({
+ *   logger: async (entry) => {
+ *     await saveToDatabase({
+ *       toolCallId: entry.options.toolCallId,
+ *       input: entry.input,
+ *       success: entry.result.ok,
+ *       durationMs: entry.durationMs,
+ *       timestamp: entry.startedAt,
+ *     });
+ *   },
+ * }).applyTo(tool);
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Composing with other middleware
+ * import { idempotency } from '@tool2agent/middleware-idempotency';
+ *
+ * const tool = logging<InputType, OutputType>({
+ *   logger: (entry) => console.log(entry),
+ * }).pipe(
+ *   idempotency<InputType, OutputType>()
+ * ).applyTo(baseTool);
+ * ```
+ */
+export function logging<InputType, OutputType>(
+  options: LoggingOptions<InputType, OutputType>,
+): Middleware<InputType, OutputType> {
+  const { logger } = options;
+
+  return createMiddleware<InputType, OutputType>({
+    transform: (tool: Tool2Agent<InputType, OutputType>): Tool2Agent<InputType, OutputType> => {
+      const { execute } = tool;
+
+      return {
+        ...tool,
+        execute: async (
+          input: InputType,
+          options: ToolCallOptions,
+        ): Promise<ToolCallResult<InputType, OutputType>> => {
+          const startedAt = new Date();
+          const startTime = performance.now();
+
+          const result = await execute(input, options);
+
+          const endTime = performance.now();
+          const completedAt = new Date();
+          const durationMs = endTime - startTime;
+
+          const logEntry: LogEntry<InputType, OutputType> = {
+            input,
+            result,
+            options,
+            durationMs,
+            startedAt,
+            completedAt,
+          };
+
+          await logger(logEntry);
+
+          return result;
+        },
+      };
+    },
+  });
+}

--- a/packages/middleware-logging/test/logging.unit.test.ts
+++ b/packages/middleware-logging/test/logging.unit.test.ts
@@ -1,0 +1,311 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { tool2agent } from '@tool2agent/ai';
+import { logging, type LogEntry } from '../src/index.js';
+import type { ToolCallOptions } from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+import type { ToolCallResult } from '@tool2agent/types';
+
+const inputSchema = z.object({ query: z.string() });
+const outputSchema = z.object({ result: z.string() });
+
+type InputType = z.infer<typeof inputSchema>;
+type OutputType = z.infer<typeof outputSchema>;
+
+describe('logging middleware', () => {
+  const createBaseTool = () =>
+    tool2agent({
+      inputSchema,
+      outputSchema,
+      execute: async (params: InputType): Promise<ToolCallResult<InputType, OutputType>> => {
+        return { ok: true, result: `Processed: ${params.query}` };
+      },
+    });
+
+  const toolCallOptions: ToolCallOptions = {
+    toolCallId: 'test-id',
+    messages: [],
+  };
+
+  describe('basic functionality', () => {
+    it('logs tool call with correct input', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.input).to.deep.equal({ query: 'test' });
+    });
+
+    it('logs tool call with correct result', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.result.ok).to.be.true;
+      if (loggedEntry!.result.ok) {
+        expect(loggedEntry!.result.result).to.equal('Processed: test');
+      }
+    });
+
+    it('logs tool call options', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.options.toolCallId).to.equal('test-id');
+    });
+
+    it('returns the original result unchanged', async () => {
+      const baseTool = createBaseTool();
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: () => {},
+      }).applyTo(baseTool);
+
+      const result = await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.true;
+      if (result.ok) {
+        expect(result.result).to.equal('Processed: test');
+      }
+    });
+  });
+
+  describe('timing information', () => {
+    it('provides duration in milliseconds', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.durationMs).to.be.a('number');
+      expect(loggedEntry!.durationMs).to.be.at.least(0);
+    });
+
+    it('provides startedAt timestamp', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      const before = new Date();
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+      const after = new Date();
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.startedAt).to.be.instanceOf(Date);
+      expect(loggedEntry!.startedAt.getTime()).to.be.at.least(before.getTime());
+      expect(loggedEntry!.startedAt.getTime()).to.be.at.most(after.getTime());
+    });
+
+    it('provides completedAt timestamp', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      const before = new Date();
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+      const after = new Date();
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.completedAt).to.be.instanceOf(Date);
+      expect(loggedEntry!.completedAt.getTime()).to.be.at.least(before.getTime());
+      expect(loggedEntry!.completedAt.getTime()).to.be.at.most(after.getTime());
+    });
+
+    it('completedAt is after or equal to startedAt', async () => {
+      const baseTool = createBaseTool();
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.completedAt.getTime()).to.be.at.least(loggedEntry!.startedAt.getTime());
+    });
+
+    it('measures duration correctly for slow operations', async () => {
+      const slowTool = tool2agent({
+        inputSchema,
+        outputSchema,
+        execute: async (params: InputType): Promise<ToolCallResult<InputType, OutputType>> => {
+          await new Promise(resolve => setTimeout(resolve, 50));
+          return { ok: true, result: `Processed: ${params.query}` };
+        },
+      });
+
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(slowTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.durationMs).to.be.at.least(40); // Allow some margin
+    });
+  });
+
+  describe('async logger support', () => {
+    it('supports async logger functions', async () => {
+      const baseTool = createBaseTool();
+      let loggerCalled = false;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: async entry => {
+          await new Promise(resolve => setTimeout(resolve, 10));
+          loggerCalled = true;
+          expect(entry.input).to.deep.equal({ query: 'test' });
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(loggerCalled).to.be.true;
+    });
+  });
+
+  describe('error logging', () => {
+    it('logs failed tool calls', async () => {
+      const failingTool = tool2agent({
+        inputSchema,
+        outputSchema,
+        execute: async (): Promise<ToolCallResult<InputType, OutputType>> => {
+          return { ok: false, problems: ['Something went wrong'] };
+        },
+      });
+
+      let loggedEntry: LogEntry<InputType, OutputType> | undefined;
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(failingTool);
+
+      const result = await loggedTool.execute({ query: 'test' }, toolCallOptions);
+
+      expect(result.ok).to.be.false;
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.result.ok).to.be.false;
+      if (!loggedEntry!.result.ok) {
+        expect(loggedEntry!.result.problems).to.deep.equal(['Something went wrong']);
+      }
+    });
+  });
+
+  describe('multiple tool calls', () => {
+    it('logs each tool call separately', async () => {
+      const baseTool = createBaseTool();
+      const loggedEntries: LogEntry<InputType, OutputType>[] = [];
+
+      const loggedTool = logging<InputType, OutputType>({
+        logger: entry => {
+          loggedEntries.push(entry);
+        },
+      }).applyTo(baseTool);
+
+      await loggedTool.execute({ query: 'first' }, { ...toolCallOptions, toolCallId: 'call-1' });
+      await loggedTool.execute({ query: 'second' }, { ...toolCallOptions, toolCallId: 'call-2' });
+      await loggedTool.execute({ query: 'third' }, { ...toolCallOptions, toolCallId: 'call-3' });
+
+      expect(loggedEntries).to.have.length(3);
+      expect(loggedEntries[0].input).to.deep.equal({ query: 'first' });
+      expect(loggedEntries[0].options.toolCallId).to.equal('call-1');
+      expect(loggedEntries[1].input).to.deep.equal({ query: 'second' });
+      expect(loggedEntries[1].options.toolCallId).to.equal('call-2');
+      expect(loggedEntries[2].input).to.deep.equal({ query: 'third' });
+      expect(loggedEntries[2].options.toolCallId).to.equal('call-3');
+    });
+  });
+
+  describe('complex input/output types', () => {
+    it('handles complex input objects', async () => {
+      const complexInputSchema = z.object({
+        name: z.string(),
+        age: z.number(),
+        tags: z.array(z.string()),
+      });
+      const complexOutputSchema = z.object({ success: z.boolean(), id: z.number() });
+
+      type ComplexInput = z.infer<typeof complexInputSchema>;
+      type ComplexOutput = z.infer<typeof complexOutputSchema>;
+
+      const baseTool = tool2agent({
+        inputSchema: complexInputSchema,
+        outputSchema: complexOutputSchema,
+        execute: async (): Promise<ToolCallResult<ComplexInput, ComplexOutput>> => {
+          return { ok: true, success: true, id: 42 };
+        },
+      });
+
+      let loggedEntry: LogEntry<ComplexInput, ComplexOutput> | undefined;
+
+      const loggedTool = logging<ComplexInput, ComplexOutput>({
+        logger: entry => {
+          loggedEntry = entry;
+        },
+      }).applyTo(baseTool);
+
+      const input: ComplexInput = {
+        name: 'John',
+        age: 30,
+        tags: ['developer', 'typescript'],
+      };
+
+      await loggedTool.execute(input, toolCallOptions);
+
+      expect(loggedEntry).to.not.be.undefined;
+      expect(loggedEntry!.input).to.deep.equal(input);
+      expect(loggedEntry!.result.ok).to.be.true;
+    });
+  });
+});

--- a/packages/middleware-logging/tsconfig-all.json
+++ b/packages/middleware-logging/tsconfig-all.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/middleware-logging/tsconfig.cjs.json
+++ b/packages/middleware-logging/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist-cjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/middleware-logging/tsconfig.json
+++ b/packages/middleware-logging/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node", "mocha", "chai"],
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,46 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
 
+  packages/middleware-logging:
+    dependencies:
+      '@tool2agent/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@tool2agent/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@ai-sdk/provider-utils':
+        specifier: ^3.0.13
+        version: 3.0.14(zod@4.1.12)
+      '@types/chai':
+        specifier: ^5.2.2
+        version: 5.2.3
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: ^24.9.2
+        version: 24.9.2
+      chai:
+        specifier: ^5.2.0
+        version: 5.3.3
+      mocha:
+        specifier: ^11.5.0
+        version: 11.7.4
+      mocha-suppress-logs:
+        specifier: ^0.6.0
+        version: 0.6.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.9.2)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+
   packages/schemas:
     dependencies:
       '@tool2agent/types':


### PR DESCRIPTION
## Summary

- Implements a logging middleware for tool2agent that logs tool call inputs, outputs, and timing information
- The logger function is configurable (as requested in the issue)
- Supports both sync and async logger functions
- Provides rich log entries including input, result, options, duration, and timestamps

## Features

- **Configurable logger**: Pass any function that receives `LogEntry<InputType, OutputType>`
- **Async support**: Logger can be async for sending logs to external services
- **Timing information**: Measures execution duration in milliseconds with start/complete timestamps
- **Composable**: Works with other middleware via `pipe()`

## Test plan

- [x] Unit tests for basic functionality (logging input, result, options)
- [x] Unit tests for timing information (duration, startedAt, completedAt)
- [x] Unit tests for async logger support
- [x] Unit tests for error/failure logging
- [x] Unit tests for multiple tool calls
- [x] Unit tests for complex input/output types
- [x] All 13 tests passing

Fixes tool2agent/tool2agent#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)